### PR TITLE
Test/example

### DIFF
--- a/contracts/example/.cargo/config.toml
+++ b/contracts/example/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/contracts/example/Cargo.toml
+++ b/contracts/example/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example"
+version = "0.1.0"
+edition = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev_dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/example/src/lib.rs
+++ b/contracts/example/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, log, symbol_short, Address, Env, IntoVal, Symbol, Val, Vec};
+
+const COUNTER: Symbol = symbol_short!("COUNTER");
+
+#[contract]
+pub struct IncrementorContract;
+
+#[contractimpl]
+impl IncrementorContract {
+    /// Increment an internal counter; return the new value.
+    pub fn increment(env: Env) -> u32 {
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0);
+
+        count += 1;
+
+        log!(&env, "count: {}", count);
+
+        env.storage().instance().set(&COUNTER, &count);
+
+        env.storage().instance().extend_ttl(100, 100);
+
+        count
+    }
+}
+
+#[contract]
+pub struct Incrementor2Contract;
+
+#[contractimpl]
+impl Incrementor2Contract {
+    pub fn increment_twice(env: Env, contract_id: Address) -> u32 {
+        let _: u32 = env.invoke_contract(&contract_id, &Symbol::new(&env, "increment"), Vec::<Val>::new(&env).into_val(&env));
+
+        log!(env, "incremented once");
+
+        let count: u32 = env.invoke_contract(&contract_id, &Symbol::new(&env, "increment"), Vec::<Val>::new(&env).into_val(&env));
+
+        log!(env, "incremented twice");
+
+        count
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/example/src/test.rs
+++ b/contracts/example/src/test.rs
@@ -1,0 +1,25 @@
+use crate::{Incrementor2Contract, Incrementor2ContractClient, IncrementorContract, IncrementorContractClient};
+use soroban_sdk::Env;
+
+#[test]
+fn increment() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, IncrementorContract);
+    let client = IncrementorContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.increment(), 1);
+    assert_eq!(client.increment(), 2);
+    assert_eq!(client.increment(), 3);
+}
+
+#[test]
+fn increment_twice() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, IncrementorContract);
+    let client = IncrementorContractClient::new(&env, &contract_id);
+
+    let _ = env.register_contract(None, Incrementor2Contract);
+    let client2 = Incrementor2ContractClient::new(&env, &contract_id);
+
+    assert_eq!(client2.increment_twice(&client.address), 2);
+}


### PR DESCRIPTION
`cargo test` in the `example` subdir gives the following error

```
---- test::increment_twice stdout ----
thread 'test::increment_twice' panicked at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host.rs:706:9:
HostError: Error(Context, MissingValue)

Event log (newest first):
   0: [Diagnostic Event] topics:[error, Error(Context, MissingValue)], data:"escalating error to panic"
   1: [Diagnostic Event] topics:[error, Error(Context, MissingValue)], data:["contract call failed", increment_twice, [CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM]]
   2: [Failed Diagnostic Event (not emitted)] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM, topics:[error, Error(Context, MissingValue)], data:["calling unknown contract function", increment_twice]
   3: [Diagnostic Event] topics:[fn_call, Bytes(0000000000000000000000000000000000000000000000000000000000000001), increment_twice], data:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM

Backtrace (newest first):
   0: backtrace::backtrace::libunwind::trace
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/libunwind.rs:93:5
      backtrace::backtrace::trace_unsynchronized
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:53:14
   2: backtrace::capture::Backtrace::create
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/capture.rs:176:9
   3: backtrace::capture::Backtrace::new_unresolved
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/capture.rs:170:9
   4: soroban_env_host::host::error::<impl soroban_env_host::host::Host>::maybe_get_debug_info::{{closure}}
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host/error.rs:290:37
   5: soroban_env_host::budget::Budget::with_shadow_mode
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/budget.rs:762:21
   6: soroban_env_host::host::Host::with_debug_mode
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host.rs:553:24
   7: soroban_env_host::host::error::<impl soroban_env_host::host::Host>::maybe_get_debug_info
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host/error.rs:287:13
   8: soroban_env_host::host::error::<impl soroban_env_host::host::Host>::error::{{closure}}
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host/error.rs:271:23
   9: soroban_env_host::budget::Budget::with_shadow_mode
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/budget.rs:762:21
  10: soroban_env_host::host::Host::with_debug_mode
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host.rs:553:24
  11: soroban_env_host::host::error::<impl soroban_env_host::host::Host>::error
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host/error.rs:258:9
  12: <soroban_env_host::host::Host as soroban_env_common::env::EnvBase>::escalate_error_to_panic
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-env-host-20.2.2/src/host.rs:705:26
  13: soroban_sdk::env::internal::reject_err::{{closure}}
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-sdk-20.3.2/src/env.rs:52:23
  14: core::result::Result<T,E>::map_err
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/result.rs:829:27
  15: soroban_sdk::env::internal::reject_err
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-sdk-20.3.2/src/env.rs:52:9
  16: <soroban_sdk::env::Env as soroban_env_common::env::Env>::call
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-sdk-20.3.2/src/env.rs:1625:13
  17: soroban_sdk::env::Env::invoke_contract
             at /Users/milap/.cargo/registry/src/index.crates.io-6f17d22bba15001f/soroban-sdk-20.3.2/src/env.rs:370:18
  18: example::Incrementor2ContractClient::increment_twice
             at src/lib.rs:30:1
  19: example::test::increment_twice
             at src/test.rs:24:16
  20: example::test::increment_twice::{{closure}}
             at src/test.rs:16:21
  21: core::ops::function::FnOnce::call_once
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/ops/function.rs:250:5


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Writing test snapshot file for test "test::increment_twice" to "test_snapshots/test/increment_twice.1.json".
```