### PR TITLE
fix(AxelarAuthVerifier): use u128 for weights and threshold

### DIFF
--- a/contracts/axelar-auth-verifier/src/contract.rs
+++ b/contracts/axelar-auth-verifier/src/contract.rs
@@ -270,7 +270,7 @@ pub fn validate_signers(env: &Env, weighted_signers: &WeightedSigners) -> bool {
         }
 
         previous_signer = signer.signer;
-        total_weight += signer.weight;
+        total_weight = total_weight.checked_add(signer.weight).unwrap();
     }
 
     if weighted_signers.threshold == 0 || total_weight < weighted_signers.threshold {

--- a/contracts/axelar-auth-verifier/src/contract.rs
+++ b/contracts/axelar-auth-verifier/src/contract.rs
@@ -238,7 +238,7 @@ impl AxelarAuthVerifier {
 
             let WeightedSigner { weight, .. } = signers.signers.get(signer_index).unwrap();
 
-            total_weight += weight;
+            total_weight = total_weight.checked_add(weight).unwrap();
 
             if total_weight >= signers.threshold {
                 return true;

--- a/contracts/axelar-auth-verifier/src/contract.rs
+++ b/contracts/axelar-auth-verifier/src/contract.rs
@@ -2,7 +2,7 @@ use core::panic;
 
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
-    contract, contractimpl, crypto::Hash, panic_with_error, Address, Bytes, BytesN, Env, Vec, U256,
+    contract, contractimpl, crypto::Hash, panic_with_error, Address, Bytes, BytesN, Env, Vec,
 };
 
 use crate::error::Error;
@@ -212,7 +212,7 @@ impl AxelarAuthVerifier {
             return false;
         }
 
-        let mut total_weight = U256::from_u32(env, 0);
+        let mut total_weight = 0u128;
         let mut signer_index = 0;
 
         for (signature, recovery_id) in signatures.into_iter() {
@@ -238,7 +238,7 @@ impl AxelarAuthVerifier {
 
             let WeightedSigner { weight, .. } = signers.signers.get(signer_index).unwrap();
 
-            total_weight = total_weight.add(&weight);
+            total_weight += weight;
 
             if total_weight >= signers.threshold {
                 return true;
@@ -258,23 +258,22 @@ pub fn validate_signers(env: &Env, weighted_signers: &WeightedSigners) -> bool {
 
     // TODO: what's the min address/hash?
     let mut previous_signer = BytesN::<32>::from_array(env, &[0; 32]);
-    let zero = U256::from_u32(env, 0);
-    let mut total_weight = zero.clone();
+    let mut total_weight = 0u128;
 
     for signer in weighted_signers.signers.iter() {
         if previous_signer >= signer.signer {
             return false;
         }
 
-        if signer.weight == zero {
+        if signer.weight == 0 {
             return false;
         }
 
         previous_signer = signer.signer;
-        total_weight = total_weight.add(&signer.weight);
+        total_weight += signer.weight;
     }
 
-    if weighted_signers.threshold == zero || total_weight < weighted_signers.threshold {
+    if weighted_signers.threshold == 0 || total_weight < weighted_signers.threshold {
         return false;
     }
 

--- a/contracts/axelar-auth-verifier/src/test.rs
+++ b/contracts/axelar-auth-verifier/src/test.rs
@@ -330,7 +330,7 @@ fn rotate_signers_fail_weight_overflow() {
         randint(1, 10),
     );
 
-    let mut new_signers = generate_signer_set(&env, randint(1, 10), BytesN::random(&env));
+    let mut new_signers = generate_signer_set(&env, randint(3, 10), BytesN::random(&env));
 
     let last_index = new_signers.signer_set.signers.len() - 1;
 

--- a/contracts/axelar-auth-verifier/src/test.rs
+++ b/contracts/axelar-auth-verifier/src/test.rs
@@ -340,7 +340,7 @@ fn rotate_signers_fail_weight_overflow() {
         new_signers.signer_set.signers.set(last_index, last_signer);
     }
 
-    // should throw an error, last signer weight is zero
+    // should throw an error, last signer weight should cause overflow
     let res = client.try_rotate_signers(&new_signers.signer_set, &false);
     assert!(res.is_err());
 }

--- a/contracts/axelar-auth-verifier/src/test.rs
+++ b/contracts/axelar-auth-verifier/src/test.rs
@@ -243,7 +243,7 @@ fn fail_validate_proof_threshold_overflow() {
     }
 
     let msg_hash = generate_random_payload_and_hash(env);
-    let mut proof = generate_proof(env, msg_hash.clone(), signers);
+    let proof = generate_proof(env, msg_hash.clone(), signers);
 
     // should panic, last signer weight should cause overflow
     client.validate_proof(&msg_hash, &proof);

--- a/contracts/axelar-auth-verifier/src/testutils.rs
+++ b/contracts/axelar-auth-verifier/src/testutils.rs
@@ -6,7 +6,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
-use soroban_sdk::{vec};
+use soroban_sdk::vec;
 
 use soroban_sdk::{symbol_short, testutils::BytesN as _, xdr::ToXdr, Address, Bytes, BytesN, Env};
 

--- a/contracts/axelar-auth-verifier/src/testutils.rs
+++ b/contracts/axelar-auth-verifier/src/testutils.rs
@@ -43,7 +43,7 @@ pub fn generate_signer_set(
             let sk = SecretKey::new(&mut OsRng);
             let pk = PublicKey::from_secret_key(&secp, &sk);
             let pk_hash: [u8; 32] = Keccak256::digest(pk.serialize_uncompressed()).into();
-            let weight = rng.gen_range(1..10) as u32;
+            let weight = rng.gen_range(1..10) as u128;
 
             (sk, (pk, pk_hash, weight))
         })
@@ -54,13 +54,13 @@ pub fn generate_signer_set(
 
     let (signers, signer_info): (std::vec::Vec<_>, std::vec::Vec<(_, _, _)>) =
         signer_keypair.into_iter().unzip();
-    let total_weight = signer_info.iter().map(|(_, _, w)| w).sum::<u32>();
+    let total_weight = signer_info.iter().map(|(_, _, w)| w).sum::<u128>();
 
     let signer_vec: std::vec::Vec<WeightedSigner> = signer_info
         .into_iter()
         .map(|(_, pk_hash, w)| WeightedSigner {
             signer: BytesN::<32>::from_array(env, &pk_hash),
-            weight: w as u128,
+            weight: w,
         })
         .collect();
 
@@ -68,7 +68,7 @@ pub fn generate_signer_set(
 
     let signer_set = WeightedSigners {
         signers: signer_vec.into_vec(env),
-        threshold: threshold as u128,
+        threshold,
         nonce: BytesN::<32>::from_array(env, &[0; 32]),
     };
 

--- a/contracts/axelar-auth-verifier/src/testutils.rs
+++ b/contracts/axelar-auth-verifier/src/testutils.rs
@@ -6,7 +6,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
-use soroban_sdk::{vec, U256};
+use soroban_sdk::{vec};
 
 use soroban_sdk::{symbol_short, testutils::BytesN as _, xdr::ToXdr, Address, Bytes, BytesN, Env};
 
@@ -60,7 +60,7 @@ pub fn generate_signer_set(
         .into_iter()
         .map(|(_, pk_hash, w)| WeightedSigner {
             signer: BytesN::<32>::from_array(env, &pk_hash),
-            weight: U256::from_u32(env, w),
+            weight: w as u128,
         })
         .collect();
 
@@ -68,7 +68,7 @@ pub fn generate_signer_set(
 
     let signer_set = WeightedSigners {
         signers: signer_vec.into_vec(env),
-        threshold: U256::from_u32(env, threshold),
+        threshold: threshold as u128,
         nonce: BytesN::<32>::from_array(env, &[0; 32]),
     };
 
@@ -90,7 +90,7 @@ pub fn generate_proof(env: &Env, data_hash: BytesN<32>, signers: TestSignerSet) 
     let msg_hash = env.crypto().keccak256(&msg);
 
     let msg_to_sign = Message::from_digest_slice(&msg_hash.to_array()).unwrap();
-    let threshold = signers.signer_set.threshold.to_u128().unwrap() as u32;
+    let threshold = signers.signer_set.threshold as u32;
     let secp = Secp256k1::new();
 
     let signatures: std::vec::Vec<_> = signers

--- a/contracts/axelar-soroban-interfaces/src/types.rs
+++ b/contracts/axelar-soroban-interfaces/src/types.rs
@@ -1,17 +1,17 @@
-use soroban_sdk::{contracttype, Address, BytesN, String, Vec, U256};
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WeightedSigner {
     pub signer: BytesN<32>,
-    pub weight: U256,
+    pub weight: u128,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WeightedSigners {
     pub signers: Vec<WeightedSigner>,
-    pub threshold: U256,
+    pub threshold: u128,
     pub nonce: BytesN<32>,
 }
 


### PR DESCRIPTION
[AXE-4337]
* [x] `AxelarAuthVerifier`: use `u128` for `weights` and `threshold`

[AXE-4337]: https://axelarnetwork.atlassian.net/browse/AXE-4337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ