### PR TITLE
feat: upgrade `soroban-sdk` version to `v21.7.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -1049,9 +1049,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44877373b3dc6c662377cb1600e3a62706d75e484b6064f9cd22e467c676b159"
+checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590add16843a61b01844e19e89bccaaee6aa21dc76809017b0662c17dc139ee9"
+checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8dc43acdd6c7e7b371acf44fc1a7dac24934ae3b2f05fafd618818548176"
+checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e25aaffe0c62eb65e0e349f725b4b8b13ad0764d78a15aab5bbccb5c4797726"
+checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e16b761459fdf3c4b62b24df3941498d14e5246e6fadfb4774ed8114d243aa4"
+checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.2.0"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667a040c424d5a479387a6ca71f9591c364cdd2cfdfb1f4227753b4d1bab2a80"
+checksum = "43793d5deb5fc27c3e14e036e24cb3afcf7d1e2a172d9166e37f3d174b928749"
 dependencies = [
  "serde",
  "serde_json",
@@ -1152,15 +1152,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.2.0"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e76cfdcf2610f97d595db27dd164abe8f38c00b745e822220c2874c185d9c6f"
+checksum = "25c539fecb2862ce0c1f49880134660a855e2d35889692e01d1e8d8a1e53f98e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
  "ctor",
  "ed25519-dalek",
  "rand",
+ "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
@@ -1172,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.2.0"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0ed4e51a37c8ef530f6704a25f14447e8bc74b9e0c2046a21cfecc5ced329"
+checksum = "a9ad528a770ec7adb524635d855b424ae2fd4fef04fb702bb0ab466a4c354d78"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1192,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.2.0"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b411868046bc9aad3d481ef57ec5db34c58016c715bf871d854c8c752872b19"
+checksum = "5b262c82d840552f71ee9254f2e928622fd803bd4df4815e65f73f73efc2fa9c"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1204,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.2.0"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71e218a6ea10c0f858993d35b168a21ac7185c936c745a34a371d76d24fba0c"
+checksum = "85a061820c2dd0bd3ece9411e0dd3aeb6ed9ca2b7d64270eda9e798c3b6dec5f"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
-soroban-sdk = { version = "21.0.1-preview.3" }
+soroban-sdk = { version = "21.7.6" }
 axelar-soroban-std = { version = "^0.1.0", path = "packages/axelar-soroban-std" }
 axelar-gas-service = { version = "^0.1.0", path = "contracts/axelar-gas-service" }
 axelar-gateway = { version = "^0.1.0", path = "contracts/axelar-gateway" }

--- a/contracts/axelar-gas-service/src/test.rs
+++ b/contracts/axelar-gas-service/src/test.rs
@@ -48,15 +48,12 @@ fn fail_not_initialized() {
 
     // collect_fees() setup
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
 
     let supply: i128 = 1000;
     let refund_amount = 1;
     let token = Token {
-        address: asset.address,
+        address: asset.address(),
         amount: refund_amount,
     };
     StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
@@ -115,15 +112,12 @@ fn fail_already_initialized() {
 fn fail_pay_gas_zero_gas_amount() {
     let (env, contract_id, _gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
 
     let sender: Address = Address::generate(&env);
     let gas_amount: i128 = 0;
     let token = Token {
-        address: asset.address.clone(),
+        address: asset.address(),
         amount: gas_amount,
     };
     let refund_address: Address = Address::generate(&env);
@@ -132,8 +126,8 @@ fn fail_pay_gas_zero_gas_amount() {
     let destination_address: String =
         String::from_str(&env, "0x4EFE356BEDeCC817cb89B4E9b796dB8bC188DC59");
 
-    let token_client = TokenClient::new(&env, &asset.address.clone());
-    StellarAssetClient::new(&env, &asset.address).mint(&sender, &gas_amount);
+    let token_client = TokenClient::new(&env, &asset.address());
+    StellarAssetClient::new(&env, &asset.address()).mint(&sender, &gas_amount);
 
     let expiration_ledger = &env.ledger().sequence() + 200;
 
@@ -159,14 +153,12 @@ fn fail_pay_gas_zero_gas_amount() {
 fn pay_gas_for_contract_call() {
     let (env, contract_id, _gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
+    let asset = &env.register_stellar_asset_contract_v2(Address::generate(&env));
+
     let sender: Address = Address::generate(&env);
     let gas_amount: i128 = 1;
     let token = Token {
-        address: asset.address.clone(),
+        address: asset.address(),
         amount: gas_amount,
     };
 
@@ -176,8 +168,8 @@ fn pay_gas_for_contract_call() {
     let destination_address: String =
         String::from_str(&env, "0x4EFE356BEDeCC817cb89B4E9b796dB8bC188DC59");
 
-    let token_client = TokenClient::new(&env, &asset.address);
-    StellarAssetClient::new(&env, &asset.address).mint(&sender, &gas_amount);
+    let token_client = TokenClient::new(&env, &asset.address());
+    StellarAssetClient::new(&env, &asset.address()).mint(&sender, &gas_amount);
 
     let expiration_ledger = &env.ledger().sequence() + 200;
 
@@ -216,16 +208,13 @@ fn pay_gas_for_contract_call() {
 fn fail_collect_fees_zero_refund_amount() {
     let (env, contract_id, gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
+    let asset = &env.register_stellar_asset_contract_v2(Address::generate(&env));
 
     let supply: i128 = 1000;
     let refund_amount = 0;
 
     let token = Token {
-        address: asset.address,
+        address: asset.address(),
         amount: refund_amount,
     };
     StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
@@ -240,16 +229,13 @@ fn fail_collect_fees_zero_refund_amount() {
 fn fail_collect_fees_insufficient_balance() {
     let (env, contract_id, gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
+    let asset = &env.register_stellar_asset_contract_v2(Address::generate(&env));
 
     let supply: i128 = 5;
     let refund_amount = 10;
 
     let token = Token {
-        address: asset.address,
+        address: asset.address(),
         amount: refund_amount,
     };
     StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
@@ -264,15 +250,13 @@ fn fail_collect_fees_insufficient_balance() {
 fn collect_fees() {
     let (env, contract_id, gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
-    let token_client = TokenClient::new(&env, &asset.address);
+    let asset = &env.register_stellar_asset_contract_v2(Address::generate(&env));
+
+    let token_client = TokenClient::new(&env, &asset.address());
     let supply: i128 = 1000;
     let refund_amount = 1;
     let token = Token {
-        address: asset.address,
+        address: asset.address(),
         amount: refund_amount,
     };
     StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
@@ -294,18 +278,16 @@ fn collect_fees() {
 fn refund() {
     let (env, contract_id, _gas_collector, client) = setup_env();
 
-    let asset = StellarAssetClient::new(
-        &env,
-        &env.register_stellar_asset_contract(Address::generate(&env)),
-    );
-    let token_client = TokenClient::new(&env, &asset.address);
+    let asset = &env.register_stellar_asset_contract_v2(Address::generate(&env));
+
+    let token_client = TokenClient::new(&env, &asset.address());
     let supply: i128 = 1000;
-    StellarAssetClient::new(&env, &asset.address).mint(&contract_id, &supply);
+    StellarAssetClient::new(&env, &asset.address()).mint(&contract_id, &supply);
 
     let receiver: Address = Address::generate(&env);
     let refund_amount: i128 = 1;
     let token = Token {
-        address: asset.address,
+        address: asset.address(),
         amount: refund_amount,
     };
 


### PR DESCRIPTION
closes [AXE-6310](https://axelarnetwork.atlassian.net/browse/AXE-6310)

## Motivation

We are currently on `soroban-sdk = { version = "21.0.1-preview.3" }`, which is outdated and has some issues with future rust versions (tests would always abort, fixed by https://github.com/stellar/rs-soroban-sdk/pull/1333). Was told that sdk versions under the same major version guarantee no breaking changes and that the [software-versions page](https://developers.stellar.org/docs/networks/software-versions#protocol-21-mainnet-june-18-2024) is incorrectly claiming that mainnet is running the preview version.

We don't need to always be on the latest version, but staying on a preview version doesn't seem ideal.

## Summary

- upgraded `soroban_sdk` version to `21.7.6`, the latest one at the time of writing
- replace uses of deprecated function (`register_stellar_asset_contract` -> `register_stellar_asset_contract_v2`)

[AXE-6310]: https://axelarnetwork.atlassian.net/browse/AXE-6310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ