### PR TITLE
ci: install stellar CLI with opt flag

### DIFF
--- a/.github/actions/compile-stellar/action.yaml
+++ b/.github/actions/compile-stellar/action.yaml
@@ -32,6 +32,7 @@ runs:
       run: cargo install "stellar-cli@${{ inputs.stellar-version }}" --features opt
 
     - name: Copy binaries
+      shell: bash
       if: steps.cache-stellar.outputs.cache-hit != 'true'
       run: |
         mkdir -p ./stellar-binaries

--- a/.github/actions/compile-stellar/action.yaml
+++ b/.github/actions/compile-stellar/action.yaml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       if: steps.cache-stellar.outputs.cache-hit != 'true'
       working-directory: ./stellar-cli
-      run: cargo install "stellar-cli@${{ inputs.stellar-version }}"
+      run: cargo install "stellar-cli@${{ inputs.stellar-version }}" --features opt
 
     - name: Copy binaries
       if: steps.cache-stellar.outputs.cache-hit != 'true'
@@ -37,6 +37,8 @@ runs:
         mkdir -p ./stellar-binaries
         cp "$HOME/.cargo/bin/stellar" ./stellar-binaries/stellar
         cp "$HOME/.cargo/bin/soroban" ./stellar-binaries/soroban
+        chmod +x ./stellar-binaries/stellar
+        chmod +x ./stellar-binaries/soroban
 
     - name: Save Stellar binaries
       if: steps.cache-stellar.outputs.cache-hit != 'true'
@@ -51,5 +53,3 @@ runs:
       run: |
         sudo cp ./stellar-binaries/stellar /usr/local/bin/stellar
         sudo cp ./stellar-binaries/soroban /usr/local/bin/soroban
-        chmod +x /usr/local/bin/stellar
-        chmod +x /usr/local/bin/soroban


### PR DESCRIPTION
* use `--features opt` flag when installing, which is required when optimizing contracts
* set `-x` permission before caching
* indicate missing `shell` field in one of the steps