### PR TITLE
feat(gas-service): add contract constructor

### DIFF
--- a/contracts/axelar-gas-service/src/contract.rs
+++ b/contracts/axelar-gas-service/src/contract.rs
@@ -1,3 +1,4 @@
+use axelar_soroban_std::assert_some;
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, String};
 
 use axelar_soroban_std::{ensure, types::Token};
@@ -13,14 +14,6 @@ pub struct AxelarGasService;
 impl AxelarGasService {
     /// Initialize the gas service contract with a gas_collector address.
     pub fn __constructor(env: Env, gas_collector: Address) -> Result<(), ContractError> {
-        ensure!(
-            env.storage()
-                .instance()
-                .get::<DataKey, bool>(&DataKey::Initialized)
-                .is_none(),
-            ContractError::AlreadyInitialized
-        );
-
         env.storage().instance().set(&DataKey::Initialized, &true);
 
         env.storage()
@@ -94,11 +87,8 @@ impl AxelarGasService {
     ///
     /// Only callable by the `gas_collector`.
     pub fn collect_fees(env: Env, receiver: Address, token: Token) -> Result<(), ContractError> {
-        let gas_collector: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::GasCollector)
-            .ok_or(ContractError::NotInitialized)?;
+        let gas_collector: Address =
+            assert_some!(env.storage().instance().get(&DataKey::GasCollector));
 
         gas_collector.require_auth();
 
@@ -128,11 +118,8 @@ impl AxelarGasService {
         receiver: Address,
         token: Token,
     ) -> Result<(), ContractError> {
-        let gas_collector: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::GasCollector)
-            .ok_or(ContractError::NotInitialized)?;
+        let gas_collector: Address =
+            assert_some!(env.storage().instance().get(&DataKey::GasCollector));
 
         gas_collector.require_auth();
 

--- a/contracts/axelar-gas-service/src/contract.rs
+++ b/contracts/axelar-gas-service/src/contract.rs
@@ -12,7 +12,7 @@ pub struct AxelarGasService;
 #[contractimpl]
 impl AxelarGasService {
     /// Initialize the gas service contract with a gas_collector address.
-    pub fn initialize_gas_service(env: Env, gas_collector: Address) -> Result<(), ContractError> {
+    pub fn __constructor(env: Env, gas_collector: Address) -> Result<(), ContractError> {
         ensure!(
             env.storage()
                 .instance()
@@ -159,11 +159,10 @@ mod tests {
     #[test]
     fn initialize_gas_service() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, AxelarGasService);
-        let client = AxelarGasServiceClient::new(&env, &contract_id);
-        let gas_collector = Address::generate(&env);
 
-        client.initialize_gas_service(&gas_collector);
+        let gas_collector = Address::generate(&env);
+        let contract_id = env.register(AxelarGasService, (&gas_collector,));
+        let _client = AxelarGasServiceClient::new(&env, &contract_id);
 
         assert!(env.as_contract(&contract_id, || {
             assert_some!(env

--- a/contracts/axelar-gas-service/src/contract.rs
+++ b/contracts/axelar-gas-service/src/contract.rs
@@ -13,14 +13,12 @@ pub struct AxelarGasService;
 #[contractimpl]
 impl AxelarGasService {
     /// Initialize the gas service contract with a gas_collector address.
-    pub fn __constructor(env: Env, gas_collector: Address) -> Result<(), ContractError> {
+    pub fn __constructor(env: Env, gas_collector: Address) {
         env.storage().instance().set(&DataKey::Initialized, &true);
 
         env.storage()
             .instance()
             .set(&DataKey::GasCollector, &gas_collector);
-
-        Ok(())
     }
 
     /// Pay for gas using a token for a contract call on a destination chain.

--- a/contracts/axelar-gas-service/src/contract.rs
+++ b/contracts/axelar-gas-service/src/contract.rs
@@ -1,4 +1,3 @@
-use axelar_soroban_std::assert_some;
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, String};
 
 use axelar_soroban_std::{ensure, types::Token};
@@ -83,8 +82,11 @@ impl AxelarGasService {
     ///
     /// Only callable by the `gas_collector`.
     pub fn collect_fees(env: Env, receiver: Address, token: Token) -> Result<(), ContractError> {
-        let gas_collector: Address =
-            assert_some!(env.storage().instance().get(&DataKey::GasCollector));
+        let gas_collector: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::GasCollector)
+            .expect("gas collector not found");
 
         gas_collector.require_auth();
 

--- a/contracts/axelar-gas-service/src/error.rs
+++ b/contracts/axelar-gas-service/src/error.rs
@@ -7,6 +7,4 @@ pub enum ContractError {
     InvalidAddress = 1,
     InvalidAmount = 2,
     InsufficientBalance = 3,
-    AlreadyInitialized = 4,
-    NotInitialized = 5,
 }

--- a/contracts/axelar-gas-service/src/storage_types.rs
+++ b/contracts/axelar-gas-service/src/storage_types.rs
@@ -3,6 +3,5 @@ use soroban_sdk::contracttype;
 #[contracttype]
 #[derive(Clone, Debug)]
 pub enum DataKey {
-    Initialized,
     GasCollector,
 }

--- a/contracts/axelar-gas-service/tests/test.rs
+++ b/contracts/axelar-gas-service/tests/test.rs
@@ -26,15 +26,14 @@ fn setup_env<'a>() -> (Env, Address, Address, AxelarGasServiceClient<'a>) {
 }
 
 #[test]
-fn initialize_gas_service() {
+fn register_gas_service() {
     let env = Env::default();
 
     let gas_collector = Address::generate(&env);
     let contract_id = env.register(AxelarGasService, (&gas_collector,));
     let client = AxelarGasServiceClient::new(&env, &contract_id);
 
-    let stored_collector_address = client.gas_collector();
-    assert_eq!(stored_collector_address, gas_collector);
+    assert_eq!(client.gas_collector(), gas_collector);
 }
 
 #[test]

--- a/contracts/axelar-gas-service/tests/test.rs
+++ b/contracts/axelar-gas-service/tests/test.rs
@@ -26,6 +26,18 @@ fn setup_env<'a>() -> (Env, Address, Address, AxelarGasServiceClient<'a>) {
 }
 
 #[test]
+fn initialize_gas_service() {
+    let env = Env::default();
+
+    let gas_collector = Address::generate(&env);
+    let contract_id = env.register(AxelarGasService, (&gas_collector,));
+    let client = AxelarGasServiceClient::new(&env, &contract_id);
+
+    let stored_collector_address = client.gas_collector();
+    assert_eq!(stored_collector_address, gas_collector);
+}
+
+#[test]
 fn fail_pay_gas_zero_gas_amount() {
     let (env, contract_id, _gas_collector, client) = setup_env();
 

--- a/contracts/axelar-gas-service/tests/test.rs
+++ b/contracts/axelar-gas-service/tests/test.rs
@@ -18,71 +18,11 @@ fn setup_env<'a>() -> (Env, Address, Address, AxelarGasServiceClient<'a>) {
 
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AxelarGasService);
-
-    let client = AxelarGasServiceClient::new(&env, &contract_id);
     let gas_collector: Address = Address::generate(&env);
-    client.initialize_gas_service(&gas_collector);
+    let contract_id = env.register(AxelarGasService, (&gas_collector,));
+    let client = AxelarGasServiceClient::new(&env, &contract_id);
 
     (env, contract_id, gas_collector, client)
-}
-
-#[test]
-fn fail_not_initialized() {
-    // only collect_fees() and refund() require initialization, so setup and call those.
-
-    // do setup_env without initializing at the end
-    let env = Env::default();
-
-    env.mock_all_auths();
-
-    let contract_id = env.register_contract(None, AxelarGasService);
-
-    let client = AxelarGasServiceClient::new(&env, &contract_id);
-    let gas_collector: Address = Address::generate(&env);
-
-    // collect_fees() setup
-
-    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
-
-    let supply: i128 = 1000;
-    let refund_amount = 1;
-    let token = Token {
-        address: asset.address(),
-        amount: refund_amount,
-    };
-    StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
-
-    assert_contract_err!(
-        client.try_collect_fees(&gas_collector, &token),
-        ContractError::NotInitialized
-    );
-
-    // refund() setup
-
-    let receiver: Address = Address::generate(&env);
-    let message_id = String::from_str(
-        &env,
-        &format!(
-            "{}-{}",
-            "0xfded3f55dec47250a52a8c0bb7038e72fa6ffaae33562f77cd2b629ef7fd424d", 0
-        ),
-    );
-
-    assert_contract_err!(
-        client.try_refund(&message_id, &receiver, &token),
-        ContractError::NotInitialized
-    );
-}
-
-#[test]
-fn fail_already_initialized() {
-    let (_env, _contract_id, gas_collector, client) = setup_env();
-
-    assert_contract_err!(
-        client.try_initialize_gas_service(&gas_collector),
-        ContractError::AlreadyInitialized
-    );
 }
 
 #[test]

--- a/contracts/example/tests/test.rs
+++ b/contracts/example/tests/test.rs
@@ -27,11 +27,9 @@ fn setup_gateway<'a>(env: &Env) -> (AxelarGatewayClient<'a>, Address, TestSigner
 }
 
 fn setup_gas_service<'a>(env: &Env) -> (AxelarGasServiceClient<'a>, Address, Address) {
-    let gas_service_id = env.register_contract(None, AxelarGasService);
-    let gas_service_client = AxelarGasServiceClient::new(env, &gas_service_id);
     let gas_collector: Address = Address::generate(&env);
-
-    gas_service_client.initialize_gas_service(&gas_collector);
+    let gas_service_id = env.register(AxelarGasService, (&gas_collector,));
+    let gas_service_client = AxelarGasServiceClient::new(env, &gas_service_id);
 
     (gas_service_client, gas_collector, gas_service_id)
 }


### PR DESCRIPTION
closes https://axelarnetwork.atlassian.net/browse/AXE-6580

## Summary

similar to #69 

added a getter for gas_collector to reduce some code duplication & to move the unit test which was querying the contract env directly to an integration test which calls this new method instead.