### PR TITLE
feat(gateway): add contract constructor

### DIFF
--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -241,6 +241,7 @@ mod tests {
     use crate::error::ContractError;
     use crate::testutils::TestSignerSet;
     use crate::types::{ProofSignature, ProofSigner, WeightedSigner, WeightedSigners};
+    use crate::AxelarGatewayClient;
 
     use soroban_sdk::{testutils::BytesN as _, BytesN, Env, Vec};
 
@@ -248,8 +249,7 @@ mod tests {
 
     use crate::{
         auth::{self, initialize_auth},
-        contract::AxelarGatewayClient,
-        testutils::{self, generate_proof, generate_signers_set, initialize, randint},
+        testutils::{self, generate_proof, generate_signers_set, randint, setup_gateway},
     };
 
     fn setup_env<'a>(
@@ -258,9 +258,7 @@ mod tests {
     ) -> (Env, TestSignerSet, AxelarGatewayClient<'a>) {
         let env = Env::default();
         env.mock_all_auths();
-
-        let (signers, contract_id) = initialize(&env, previous_signers_retention, num_signers);
-        let client = AxelarGatewayClient::new(&env, &contract_id);
+        let (signers, client) = setup_gateway(&env, previous_signers_retention, num_signers);
 
         (env, signers, client)
     }

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -113,7 +113,8 @@ pub fn rotate_signers(
 pub fn epoch(env: &Env) -> u64 {
     env.storage()
         .instance()
-        .get(&DataKey::Epoch).expect("epoch not found")
+        .get(&DataKey::Epoch)
+        .expect("epoch not found")
 }
 
 pub fn epoch_by_signers_hash(env: &Env, signers_hash: BytesN<32>) -> Result<u64, ContractError> {

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -242,16 +242,13 @@ mod tests {
     use crate::testutils::TestSignerSet;
     use crate::types::{ProofSignature, ProofSigner, WeightedSigner, WeightedSigners};
 
-    use soroban_sdk::{
-        testutils::{Address as _, BytesN as _},
-        Address, BytesN, Env, Vec,
-    };
+    use soroban_sdk::{testutils::BytesN as _, BytesN, Env, Vec};
 
     use axelar_soroban_std::{assert_err, assert_ok};
 
     use crate::{
         auth::{self, initialize_auth},
-        contract::{AxelarGateway, AxelarGatewayClient},
+        contract::AxelarGatewayClient,
         testutils::{self, generate_proof, generate_signers_set, initialize, randint},
     };
 
@@ -275,7 +272,7 @@ mod tests {
 
     #[test]
     fn fails_with_empty_signer_set() {
-        let (env, signers, client) = setup_env(1, randint(1, 10));
+        let (env, _signers, client) = setup_env(1, randint(1, 10));
 
         // create an empty WeightedSigners vector
         let empty_signer_set = Vec::<WeightedSigners>::new(&env);
@@ -431,7 +428,7 @@ mod tests {
     }
     #[test]
     fn fail_validate_proof_threshold_overflow() {
-        let (env, signers, client) = setup_env(randint(0, 10), randint(1, 10));
+        let (env, mut signers, client) = setup_env(randint(0, 10), randint(1, 10));
 
         let last_index = signers.signers.signers.len() - 1;
 
@@ -488,7 +485,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_zero_weight() {
-        let (env, _, client) = setup_env(1, randint(1, 10));
+        let (env, _, _client) = setup_env(1, randint(1, 10));
 
         let mut new_signers = generate_signers_set(&env, randint(1, 10), BytesN::random(&env));
 
@@ -509,7 +506,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_weight_overflow() {
-        let (env, _, client) = setup_env(1, randint(1, 10));
+        let (env, _, _client) = setup_env(1, randint(1, 10));
 
         let mut new_signers = generate_signers_set(&env, randint(3, 10), BytesN::random(&env));
 
@@ -530,7 +527,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_zero_threshold() {
-        let (env, _, client) = setup_env(1, randint(1, 10));
+        let (env, _, _client) = setup_env(1, randint(1, 10));
         let mut new_signers = generate_signers_set(&env, randint(1, 10), BytesN::random(&env));
 
         // set the threshold to zero
@@ -545,7 +542,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_low_total_weight() {
-        let (env, _, client) = setup_env(1, randint(1, 10));
+        let (env, _, _client) = setup_env(1, randint(1, 10));
         let mut new_signers = generate_signers_set(&env, randint(1, 10), BytesN::random(&env));
 
         let total_weight = new_signers
@@ -570,7 +567,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_wrong_signer_order() {
-        let (env, _, client) = setup_env(1, randint(1, 10));
+        let (env, _, _client) = setup_env(1, randint(1, 10));
 
         let min_signers = 2; // need at least 2 signers to test incorrect ordering
         let mut new_signers =
@@ -630,7 +627,7 @@ mod tests {
 
         // Proof from the first signer set should still be valid
         let proof = generate_proof(&env, msg_hash.clone(), original_signers.clone());
-        env.as_contract(&contract_id, || {
+        env.as_contract(&client.address, || {
             assert!(!assert_ok!(auth::validate_proof(&env, &msg_hash, proof)));
         })
     }
@@ -648,7 +645,7 @@ mod tests {
                 randint(1, 10),
                 original_signers.domain_separator.clone(),
             );
-            testutils::rotate_signers(&env, &client.address(), new_signers.clone());
+            testutils::rotate_signers(&env, &client.address, new_signers.clone());
         }
 
         // Proof from the first signer set should fail
@@ -664,7 +661,7 @@ mod tests {
 
     #[test]
     fn rotate_signers_fail_duplicated_signers() {
-        let (env, contract_id, client) = setup_env(1, randint(1, 10));
+        let (env, signers, client) = setup_env(1, randint(1, 10));
 
         let msg_hash = BytesN::random(&env);
         let new_signers = generate_signers_set(&env, randint(1, 10), signers.domain_separator);

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -50,7 +50,7 @@ pub fn validate_proof(
 
     let signers_epoch = epoch_by_signers_hash(env, signers_hash.clone())?;
 
-    let current_epoch = epoch(env)?;
+    let current_epoch = epoch(env);
 
     let is_latest_signers: bool = signers_epoch == current_epoch;
 
@@ -58,7 +58,7 @@ pub fn validate_proof(
         .storage()
         .instance()
         .get(&DataKey::PreviousSignerRetention)
-        .ok_or(ContractError::NotInitialized)?;
+        .expect("previous_signers_retention not found");
 
     ensure!(
         current_epoch - signers_epoch <= previous_signers_retention,
@@ -86,7 +86,7 @@ pub fn rotate_signers(
 
     let new_signers_hash = new_signers.hash(env);
 
-    let new_epoch: u64 = epoch(env)? + 1;
+    let new_epoch: u64 = epoch(env) + 1;
 
     env.storage().instance().set(&DataKey::Epoch, &new_epoch);
 
@@ -110,11 +110,10 @@ pub fn rotate_signers(
     Ok(())
 }
 
-pub fn epoch(env: &Env) -> Result<u64, ContractError> {
+pub fn epoch(env: &Env) -> u64 {
     env.storage()
         .instance()
-        .get(&DataKey::Epoch)
-        .ok_or(ContractError::NotInitialized)
+        .get(&DataKey::Epoch).expect("epoch not found")
 }
 
 pub fn epoch_by_signers_hash(env: &Env, signers_hash: BytesN<32>) -> Result<u64, ContractError> {
@@ -151,7 +150,7 @@ fn update_rotation_timestamp(env: &Env, enforce_rotation_delay: bool) -> Result<
         .storage()
         .instance()
         .get(&DataKey::MinimumRotationDelay)
-        .unwrap();
+        .expect("minimum_rotation_delay not found");
 
     let last_rotation_timestamp: u64 = env
         .storage()

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn validate_proof() {
-        let (env, signers, client) = setup_env(1, 5);
+        let (env, signers, client) = setup_env(randint(0, 10), randint(1, 10));
 
         let msg_hash: BytesN<32> = BytesN::random(&env);
         let proof = generate_proof(&env, msg_hash.clone(), signers);

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_initialize() {
+    fn register_auth() {
         setup_env(randint(0, 10), randint(1, 10));
     }
 

--- a/contracts/axelar-gateway/src/contract.rs
+++ b/contracts/axelar-gateway/src/contract.rs
@@ -200,7 +200,7 @@ impl AxelarGateway {
         bypass_rotation_delay: bool,
     ) -> Result<(), ContractError> {
         if bypass_rotation_delay {
-            Self::operator(&env)?.require_auth();
+            Self::operator(&env).require_auth();
         }
 
         let data_hash: BytesN<32> = signers.signers_rotation_hash(&env);
@@ -216,8 +216,8 @@ impl AxelarGateway {
         Ok(())
     }
 
-    pub fn transfer_operatorship(env: Env, new_operator: Address) -> Result<(), ContractError> {
-        let operator: Address = Self::operator(&env)?;
+    pub fn transfer_operatorship(env: Env, new_operator: Address) {
+        let operator: Address = Self::operator(&env);
         operator.require_auth();
 
         env.storage()
@@ -225,18 +225,16 @@ impl AxelarGateway {
             .set(&DataKey::Operator, &new_operator);
 
         event::transfer_operatorship(&env, operator, new_operator);
-
-        Ok(())
     }
 
-    pub fn operator(env: &Env) -> Result<Address, ContractError> {
+    pub fn operator(env: &Env) -> Address {
         env.storage()
             .instance()
             .get(&DataKey::Operator)
-            .ok_or(ContractError::NotInitialized)
+            .expect("operator not found")
     }
 
-    pub fn epoch(env: &Env) -> Result<u64, ContractError> {
+    pub fn epoch(env: &Env) -> u64 {
         auth::epoch(env)
     }
 
@@ -244,30 +242,26 @@ impl AxelarGateway {
         String::from_str(&env, CONTRACT_VERSION)
     }
 
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
-        Self::owner(&env)?.require_auth();
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        Self::owner(&env).require_auth();
 
         env.deployer().update_current_contract_wasm(new_wasm_hash);
-
-        Ok(())
     }
 
-    pub fn transfer_ownership(env: Env, new_owner: Address) -> Result<(), ContractError> {
-        let owner: Address = Self::owner(&env)?;
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        let owner: Address = Self::owner(&env);
         owner.require_auth();
 
         env.storage().instance().set(&DataKey::Owner, &new_owner);
 
         event::transfer_ownership(&env, owner, new_owner);
-
-        Ok(())
     }
 
-    pub fn owner(env: &Env) -> Result<Address, ContractError> {
+    pub fn owner(env: &Env) -> Address {
         env.storage()
             .instance()
             .get(&DataKey::Owner)
-            .ok_or(ContractError::NotInitialized)
+            .expect("owner not found")
     }
 
     pub fn epoch_by_signers_hash(

--- a/contracts/axelar-gateway/src/contract.rs
+++ b/contracts/axelar-gateway/src/contract.rs
@@ -24,7 +24,7 @@ pub struct AxelarGateway;
 #[contractimpl]
 impl AxelarGateway {
     /// Initialize the gateway
-    pub fn initialize(
+    pub fn __constructor(
         env: Env,
         owner: Address,
         operator: Address,
@@ -33,14 +33,6 @@ impl AxelarGateway {
         previous_signers_retention: u64,
         initial_signers: Vec<WeightedSigners>,
     ) -> Result<(), ContractError> {
-        ensure!(
-            env.storage()
-                .instance()
-                .get::<DataKey, bool>(&DataKey::Initialized)
-                .is_none(),
-            ContractError::AlreadyInitialized
-        );
-
         env.storage().instance().set(&DataKey::Initialized, &true);
 
         env.storage().instance().set(&DataKey::Owner, &owner);

--- a/contracts/axelar-gateway/src/contract.rs
+++ b/contracts/axelar-gateway/src/contract.rs
@@ -33,8 +33,6 @@ impl AxelarGateway {
         previous_signers_retention: u64,
         initial_signers: Vec<WeightedSigners>,
     ) -> Result<(), ContractError> {
-        env.storage().instance().set(&DataKey::Initialized, &true);
-
         env.storage().instance().set(&DataKey::Owner, &owner);
         env.storage().instance().set(&DataKey::Operator, &operator);
 

--- a/contracts/axelar-gateway/src/error.rs
+++ b/contracts/axelar-gateway/src/error.rs
@@ -4,23 +4,20 @@ use soroban_sdk::contracterror;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
-    // General
-    NotInitialized = 1,
-    AlreadyInitialized = 2,
     // Auth
-    InvalidThreshold = 3,
-    InvalidProof = 4,
-    InvalidSigners = 5,
-    InsufficientRotationDelay = 6,
-    InvalidSignatures = 7,
-    InvalidWeight = 8,
-    WeightOverflow = 9,
-    NotLatestSigners = 10,
-    DuplicateSigners = 11,
-    InvalidSignersHash = 12,
-    InvalidEpoch = 13,
+    InvalidThreshold = 1,
+    InvalidProof = 2,
+    InvalidSigners = 3,
+    InsufficientRotationDelay = 4,
+    InvalidSignatures = 5,
+    InvalidWeight = 6,
+    WeightOverflow = 7,
+    NotLatestSigners = 8,
+    DuplicateSigners = 9,
+    InvalidSignersHash = 10,
+    InvalidEpoch = 11,
     // Messages
-    EmptyMessages = 14,
+    EmptyMessages = 12,
     // Executable
-    NotApproved = 15,
+    NotApproved = 13,
 }

--- a/contracts/axelar-gateway/src/storage_types.rs
+++ b/contracts/axelar-gateway/src/storage_types.rs
@@ -19,7 +19,6 @@ pub enum MessageApprovalValue {
 #[derive(Clone, Debug)]
 pub enum DataKey {
     /// Gateway
-    Initialized,
     Owner,
     Operator,
     MessageApproval(MessageApprovalKey),

--- a/contracts/axelar-gateway/src/testutils.rs
+++ b/contracts/axelar-gateway/src/testutils.rs
@@ -36,16 +36,16 @@ pub fn initialize(
     let operator = Address::generate(&env);
     let signer_set = generate_signers_set(env, num_signers, BytesN::random(env));
     let initial_signers = vec![&env, signer_set.signers.clone()];
-    let minimum_rotation_delay = 0;
+    let minimum_rotation_delay: u64 = 0;
 
     let contract_id = env.register(
         AxelarGateway,
         (
-            &owner,
-            &operator,
+            owner,
+            operator,
             &signer_set.domain_separator,
             minimum_rotation_delay,
-            (previous_signers_retention as u64),
+            previous_signers_retention as u64,
             initial_signers,
         ),
     );

--- a/contracts/axelar-gateway/src/testutils.rs
+++ b/contracts/axelar-gateway/src/testutils.rs
@@ -179,7 +179,7 @@ pub fn generate_proof(env: &Env, data_hash: BytesN<32>, signer_set: TestSignerSe
 pub fn rotate_signers(env: &Env, contract_id: &Address, new_signers: TestSignerSet) {
     let mut epoch_val: u64 = 0;
     env.as_contract(contract_id, || {
-        epoch_val = assert_ok!(epoch(env)) + 1;
+        epoch_val = epoch(env) + 1;
         assert_ok!(auth::rotate_signers(env, &new_signers.signers, false));
     });
 

--- a/contracts/axelar-gateway/tests/test.rs
+++ b/contracts/axelar-gateway/tests/test.rs
@@ -1,14 +1,12 @@
 use axelar_gateway::testutils::{
     generate_proof, generate_signers_set, generate_test_message, get_approve_hash, initialize,
-    randint,
+    randint, TestSignerSet,
 };
-use axelar_gateway::{AxelarGateway, AxelarGatewayClient};
+use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::{
     assert_contract_err, assert_invocation, assert_invoke_auth_err, assert_invoke_auth_ok,
     assert_last_emitted_event,
 };
-use soroban_sdk::testutils::BytesN as _;
-
 use axelar_gateway::error::ContractError;
 use axelar_gateway::types::Message;
 use soroban_sdk::Symbol;
@@ -21,83 +19,22 @@ use soroban_sdk::{
 const DESTINATION_CHAIN: &str = "ethereum";
 const DESTINATION_ADDRESS: &str = "0x4EFE356BEDeCC817cb89B4E9b796dB8bC188DC59";
 
-fn setup_env<'a>() -> (Env, Address, AxelarGatewayClient<'a>) {
+fn setup_env<'a>(
+    previous_signers_retention: u32,
+    num_signers: u32,
+) -> (Env, TestSignerSet, AxelarGatewayClient<'a>) {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AxelarGateway);
+    let (signers, contract_id) = initialize(&env, previous_signers_retention, num_signers);
     let client = AxelarGatewayClient::new(&env, &contract_id);
 
-    (env, contract_id, client)
-}
-
-#[test]
-fn fails_if_already_initialized() {
-    let (env, _contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    // doing the process from testutils::initialize() manually so we can
-    // use try_initialize for the second call
-    let num_signers = randint(1, 10);
-    let previous_signers_retention = 1;
-
-    let signer_set = generate_signers_set(&env, num_signers, BytesN::random(&env));
-    let initial_signers = vec![&env, signer_set.signers.clone()];
-    let minimum_rotation_delay = 0;
-
-    client.initialize(
-        &owner,
-        &operator,
-        &signer_set.domain_separator,
-        &minimum_rotation_delay,
-        &(previous_signers_retention as u64),
-        &initial_signers,
-    );
-
-    assert_contract_err!(
-        client.try_initialize(
-            &owner,
-            &operator,
-            &signer_set.domain_separator,
-            &minimum_rotation_delay,
-            &(previous_signers_retention as u64),
-            &initial_signers,
-        ),
-        ContractError::AlreadyInitialized
-    );
-}
-
-#[test]
-/// Two functions in the gateway contract require initialization:
-/// rotate_signers when bypass_rotation_delay = true
-/// transfer_operatorship
-fn fail_if_not_initialized() {
-    let (env, _contract_id, client) = setup_env();
-    let new_operator = Address::generate(&env);
-
-    assert_contract_err!(
-        client.try_transfer_operatorship(&new_operator),
-        ContractError::NotInitialized
-    );
-
-    let num_signers = randint(1, 10);
-    let signers = generate_signers_set(&env, num_signers, BytesN::random(&env));
-
-    let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
-    let data_hash = new_signers.signers.hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers);
-
-    let bypass_rotation_delay = true;
-    assert_contract_err!(
-        client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay),
-        ContractError::NotInitialized
-    );
+    (env, signers, client)
 }
 
 #[test]
 fn call_contract() {
-    let (env, contract_id, client) = setup_env();
+    let (env, _signers, client) = setup_env(1, 5);
 
     let user: Address = Address::generate(&env);
     let destination_chain = String::from_str(&env, DESTINATION_CHAIN);
@@ -109,7 +46,7 @@ fn call_contract() {
     assert_invocation(
         &env,
         &user,
-        &contract_id,
+        &client.address,
         "call_contract",
         (
             &user,
@@ -121,7 +58,7 @@ fn call_contract() {
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (
             Symbol::new(&env, "contract_called"),
             user,
@@ -135,7 +72,7 @@ fn call_contract() {
 
 #[test]
 fn validate_message() {
-    let (env, contract_id, client) = setup_env();
+    let (env, _signers, client) = setup_env(1, 5);
 
     let (
         Message {
@@ -160,7 +97,7 @@ fn validate_message() {
     assert_invocation(
         &env,
         &contract_address,
-        &contract_id,
+        &client.address,
         "validate_message",
         (
             &contract_address,
@@ -176,7 +113,7 @@ fn validate_message() {
 
 #[test]
 fn approve_message() {
-    let (env, contract_id, client) = setup_env();
+    let (env, signers, client) = setup_env(1, randint(1, 10));
     let (message, _) = generate_test_message(&env);
     let Message {
         source_chain,
@@ -186,10 +123,6 @@ fn approve_message() {
         payload_hash,
     } = message.clone();
 
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, randint(1, 10));
-
     let messages = vec![&env, message.clone()];
     let data_hash = get_approve_hash(&env, messages.clone());
     let proof = generate_proof(&env, data_hash, signers);
@@ -197,7 +130,7 @@ fn approve_message() {
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (Symbol::new(&env, "message_approved"), message.clone()),
         (),
     );
@@ -222,7 +155,7 @@ fn approve_message() {
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (Symbol::new(&env, "message_executed"), message.clone()),
         (),
     );
@@ -242,11 +175,8 @@ fn approve_message() {
 
 #[test]
 fn fail_execute_invalid_proof() {
-    let (env, _contract_id, client) = setup_env();
+    let (env, signers, client) = setup_env(1, randint(1, 10));
     let (message, _) = generate_test_message(&env);
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, randint(1, 10));
 
     let invalid_signers = generate_signers_set(&env, randint(1, 10), signers.domain_separator);
 
@@ -262,11 +192,7 @@ fn fail_execute_invalid_proof() {
 
 #[test]
 fn approve_messages_fail_empty_messages() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    let signers = initialize(&env, &client, owner, operator, 1, randint(1, 10));
+    let (env, signers, client) = setup_env(1, randint(1, 10));
 
     let messages = soroban_sdk::Vec::new(&env);
     let data_hash = get_approve_hash(&env, messages.clone());
@@ -280,12 +206,8 @@ fn approve_messages_fail_empty_messages() {
 
 #[test]
 fn approve_messages_skip_duplicate_message() {
-    let (env, _, client) = setup_env();
+    let (env, signers, client) = setup_env(1, randint(1, 10));
     let (message, _) = generate_test_message(&env);
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    let signers = initialize(&env, &client, owner, operator, 1, randint(1, 10));
 
     let messages = vec![&env, message.clone()];
     let data_hash = get_approve_hash(&env, messages.clone());
@@ -302,10 +224,8 @@ fn approve_messages_skip_duplicate_message() {
 
 #[test]
 fn rotate_signers() {
-    let (env, contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
+
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
     let proof = generate_proof(&env, data_hash.clone(), signers);
@@ -316,7 +236,7 @@ fn rotate_signers() {
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (
             Symbol::new(&env, "signers_rotated"),
             new_epoch,
@@ -334,7 +254,7 @@ fn rotate_signers() {
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (Symbol::new(&env, "message_approved"), message),
         (),
     );
@@ -342,10 +262,7 @@ fn rotate_signers() {
 
 #[test]
 fn rotate_signers_bypass_rotation_delay() {
-    let (env, contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator.clone(), 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
     let proof = generate_proof(&env, data_hash.clone(), signers.clone());
@@ -353,13 +270,13 @@ fn rotate_signers_bypass_rotation_delay() {
     let new_epoch: u64 = client.epoch() + 1;
 
     assert_invoke_auth_ok!(
-        operator,
+        client.operator(),
         client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
     );
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (
             Symbol::new(&env, "signers_rotated"),
             new_epoch,
@@ -371,20 +288,20 @@ fn rotate_signers_bypass_rotation_delay() {
 
 #[test]
 fn rotate_signers_bypass_rotation_delay_unauthorized() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let not_operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner.clone(), operator.clone(), 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
+
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
+
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
     let proof = generate_proof(&env, data_hash.clone(), signers);
     let bypass_rotation_delay = true;
 
     assert_invoke_auth_err!(
-        owner,
+        client.owner(),
         client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
     );
+
+    let not_operator = Address::generate(&env);
     assert_invoke_auth_err!(
         not_operator,
         client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
@@ -393,10 +310,8 @@ fn rotate_signers_bypass_rotation_delay_unauthorized() {
 
 #[test]
 fn rotate_signers_fail_not_latest_signers() {
-    let (env, _contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
+
     let bypass_rotation_delay = false;
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
@@ -416,27 +331,16 @@ fn rotate_signers_fail_not_latest_signers() {
 
 #[test]
 fn transfer_operatorship() {
-    let (env, contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
+    let (env, _signers, client) = setup_env(1, randint(1, 10));
+
+    let operator = client.operator();
     let new_operator = Address::generate(&env);
-
-    initialize(
-        &env,
-        &client,
-        owner.clone(),
-        operator.clone(),
-        1,
-        randint(1, 10),
-    );
-
-    assert_eq!(client.operator(), operator);
 
     assert_invoke_auth_ok!(operator, client.try_transfer_operatorship(&new_operator));
 
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (
             Symbol::new(&env, "operatorship_transferred"),
             operator.clone(),
@@ -450,23 +354,13 @@ fn transfer_operatorship() {
 
 #[test]
 fn transfer_operatorship_unauthorized() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
+    let (env, _, client) = setup_env(1, randint(1, 10));
     let not_operator = Address::generate(&env);
 
-    initialize(
-        &env,
-        &client,
-        owner.clone(),
-        operator.clone(),
-        1,
-        randint(1, 10),
+    assert_invoke_auth_err!(
+        client.owner(),
+        client.try_transfer_operatorship(&client.owner())
     );
-
-    assert_eq!(client.operator(), operator);
-
-    assert_invoke_auth_err!(owner, client.try_transfer_operatorship(&owner));
     assert_invoke_auth_err!(
         not_operator,
         client.try_transfer_operatorship(&not_operator)
@@ -475,27 +369,15 @@ fn transfer_operatorship_unauthorized() {
 
 #[test]
 fn transfer_ownership() {
-    let (env, contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
+    let (env, _signers, client) = setup_env(1, randint(1, 10));
+
+    let owner = client.owner();
     let new_owner = Address::generate(&env);
 
-    initialize(
-        &env,
-        &client,
-        owner.clone(),
-        operator.clone(),
-        1,
-        randint(1, 10),
-    );
-
-    assert_eq!(client.owner(), owner);
-
     assert_invoke_auth_ok!(owner, client.try_transfer_ownership(&new_owner));
-
     assert_last_emitted_event(
         &env,
-        &contract_id,
+        &client.address,
         (
             Symbol::new(&env, "ownership_transferred"),
             owner,
@@ -509,32 +391,21 @@ fn transfer_ownership() {
 
 #[test]
 fn transfer_ownership_unauthorized() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
+    let (env, _, client) = setup_env(1, randint(1, 10));
+
     let new_owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    initialize(
-        &env,
-        &client,
-        owner.clone(),
-        operator.clone(),
-        1,
-        randint(1, 10),
-    );
-
-    assert_eq!(client.owner(), owner);
 
     assert_invoke_auth_err!(new_owner, client.try_transfer_ownership(&new_owner));
-    assert_invoke_auth_err!(operator, client.try_transfer_ownership(&operator));
+    assert_invoke_auth_err!(
+        client.operator(),
+        client.try_transfer_ownership(&client.operator())
+    );
 }
 
 #[test]
 fn epoch_by_signers_hash() {
-    let (env, _contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
+
     let bypass_rotation_delay = false;
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
@@ -551,7 +422,7 @@ fn epoch_by_signers_hash() {
 
 #[test]
 fn epoch_by_signers_hash_fail_invalid_signers() {
-    let (env, _, client) = setup_env();
+    let (env, _, client) = setup_env(1, 5);
     let signers_hash = BytesN::<32>::from_array(&env, &[1; 32]);
 
     assert_contract_err!(
@@ -562,10 +433,8 @@ fn epoch_by_signers_hash_fail_invalid_signers() {
 
 #[test]
 fn signers_hash_by_epoch() {
-    let (env, _contract_id, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signers = initialize(&env, &client, owner, operator, 1, 5);
+    let (env, signers, client) = setup_env(1, 5);
+
     let bypass_rotation_delay = false;
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
@@ -583,7 +452,7 @@ fn signers_hash_by_epoch() {
 
 #[test]
 fn signers_hash_by_epoch_fail_invalid_epoch() {
-    let (_, _, client) = setup_env();
+    let (_, _, client) = setup_env(1, 5);
     let invalid_epoch = 43u64;
 
     assert_contract_err!(
@@ -594,11 +463,7 @@ fn signers_hash_by_epoch_fail_invalid_epoch() {
 
 #[test]
 fn version() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    initialize(&env, &client, owner.clone(), operator, 1, randint(1, 10));
+    let (env, _signers, client) = setup_env(1, randint(1, 10));
 
     assert_eq!(
         client.version(),
@@ -609,36 +474,20 @@ fn version() {
 #[test]
 #[should_panic(expected = "HostError: Error(Storage, MissingValue)")]
 fn upgrade_invalid_wasm_hash() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
+    let (env, _, client) = setup_env(1, randint(1, 10));
+
     let new_wasm_hash = BytesN::<32>::from_array(&env, &[0; 32]);
-
-    initialize(&env, &client, owner, operator, 1, randint(1, 10));
-
     // Should panic with invalid wasm hash
     client.upgrade(&new_wasm_hash);
 }
 
 #[test]
 fn upgrade_unauthorized() {
-    let (env, _, client) = setup_env();
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
+    let (env, _signers, client) = setup_env(1, randint(1, 10));
+
     let not_owner = Address::generate(&env);
     let new_wasm_hash = BytesN::<32>::from_array(&env, &[0; 32]);
 
-    initialize(
-        &env,
-        &client,
-        owner.clone(),
-        operator.clone(),
-        1,
-        randint(1, 10),
-    );
-
-    assert_eq!(client.owner(), owner);
-
     assert_invoke_auth_err!(not_owner, client.try_upgrade(&new_wasm_hash));
-    assert_invoke_auth_err!(operator, client.try_upgrade(&new_wasm_hash));
+    assert_invoke_auth_err!(client.operator(), client.try_upgrade(&new_wasm_hash));
 }

--- a/contracts/axelar-gateway/tests/test.rs
+++ b/contracts/axelar-gateway/tests/test.rs
@@ -1,14 +1,14 @@
+use axelar_gateway::error::ContractError;
 use axelar_gateway::testutils::{
     generate_proof, generate_signers_set, generate_test_message, get_approve_hash, initialize,
     randint, TestSignerSet,
 };
+use axelar_gateway::types::Message;
 use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::{
     assert_contract_err, assert_invocation, assert_invoke_auth_err, assert_invoke_auth_ok,
     assert_last_emitted_event,
 };
-use axelar_gateway::error::ContractError;
-use axelar_gateway::types::Message;
 use soroban_sdk::Symbol;
 use soroban_sdk::{
     bytes,

--- a/contracts/axelar-gateway/tests/test.rs
+++ b/contracts/axelar-gateway/tests/test.rs
@@ -1,7 +1,7 @@
 use axelar_gateway::error::ContractError;
 use axelar_gateway::testutils::{
-    generate_proof, generate_signers_set, generate_test_message, get_approve_hash, initialize,
-    randint, TestSignerSet,
+    generate_proof, generate_signers_set, generate_test_message, get_approve_hash, randint,
+    setup_gateway, TestSignerSet,
 };
 use axelar_gateway::types::Message;
 use axelar_gateway::AxelarGatewayClient;
@@ -25,9 +25,7 @@ fn setup_env<'a>(
 ) -> (Env, TestSignerSet, AxelarGatewayClient<'a>) {
     let env = Env::default();
     env.mock_all_auths();
-
-    let (signers, contract_id) = initialize(&env, previous_signers_retention, num_signers);
-    let client = AxelarGatewayClient::new(&env, &contract_id);
+    let (signers, client) = setup_gateway(&env, previous_signers_retention, num_signers);
 
     (env, signers, client)
 }

--- a/contracts/axelar-gateway/tests/test.rs
+++ b/contracts/axelar-gateway/tests/test.rs
@@ -108,7 +108,8 @@ fn validate_message() {
         ),
     );
 
-    assert_eq!(env.events().all().len(), 0);
+    // there is an event emitted when initializing, ensure that no more are emitted
+    assert_eq!(env.events().all().len(), 1);
 }
 
 #[test]

--- a/contracts/example/tests/test.rs
+++ b/contracts/example/tests/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 
 use axelar_gas_service::contract::AxelarGasService;
 use axelar_gas_service::AxelarGasServiceClient;
-use axelar_gateway::testutils::{generate_proof, get_approve_hash, initialize, TestSignerSet};
+use axelar_gateway::testutils::{self, generate_proof, get_approve_hash, TestSignerSet};
 use axelar_gateway::types::Message;
 use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::assert_last_emitted_event;
@@ -17,10 +17,8 @@ use soroban_sdk::{
 use soroban_sdk::{Bytes, Symbol};
 
 fn setup_gateway<'a>(env: &Env) -> (TestSignerSet, AxelarGatewayClient<'a>) {
-    let (signers, gateway_id) = initialize(env, 0, 5);
-    let gateway_client = AxelarGatewayClient::new(env, &gateway_id);
-
-    (signers, gateway_client)
+    let (signers, client) = testutils::setup_gateway(env, 0, 5);
+    (signers, client)
 }
 
 fn setup_gas_service<'a>(env: &Env) -> (AxelarGasServiceClient<'a>, Address, Address) {

--- a/integration-tests/tests/gmp.rs
+++ b/integration-tests/tests/gmp.rs
@@ -1,6 +1,6 @@
 use axelar_gateway::testutils::{generate_proof, get_approve_hash, initialize, TestSignerSet};
 use axelar_gateway::types::Message;
-use axelar_gateway::{AxelarGateway, AxelarGatewayClient};
+use axelar_gateway::{AxelarGatewayClient};
 use axelar_soroban_std::assert_last_emitted_event;
 use soroban_sdk::{contract, contractimpl, log, Bytes, Symbol};
 use soroban_sdk::{
@@ -53,12 +53,8 @@ impl AxelarApp {
 }
 
 fn setup_gateway<'a>(env: &Env) -> (AxelarGatewayClient<'a>, TestSignerSet) {
-    let gateway_id = env.register_contract(None, AxelarGateway);
+    let (signers, gateway_id) = initialize(env, 0, 5);
     let gateway_client = AxelarGatewayClient::new(env, &gateway_id);
-    let owner = Address::generate(env);
-    let operator = Address::generate(env);
-    let signers = initialize(env, &gateway_client, owner, operator, 0, 5);
-
     (gateway_client, signers)
 }
 

--- a/integration-tests/tests/gmp.rs
+++ b/integration-tests/tests/gmp.rs
@@ -1,4 +1,4 @@
-use axelar_gateway::testutils::{generate_proof, get_approve_hash, initialize, TestSignerSet};
+use axelar_gateway::testutils::{generate_proof, get_approve_hash, setup_gateway};
 use axelar_gateway::types::Message;
 use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::assert_last_emitted_event;
@@ -50,12 +50,6 @@ impl AxelarApp {
     }
 }
 
-fn setup_gateway<'a>(env: &Env) -> (AxelarGatewayClient<'a>, TestSignerSet) {
-    let (signers, gateway_id) = initialize(env, 0, 5);
-    let gateway_client = AxelarGatewayClient::new(env, &gateway_id);
-    (gateway_client, signers)
-}
-
 fn setup_app<'a>(env: &Env, gateway: &Address) -> AxelarAppClient<'a> {
     let contract_id = env.register_contract(None, AxelarApp);
     let client = AxelarAppClient::new(env, &contract_id);
@@ -71,12 +65,12 @@ fn test_gmp() {
 
     // Setup source Axelar gateway
     let source_chain = String::from_str(&env, "source");
-    let (source_gateway_client, _) = setup_gateway(&env);
+    let (_, source_gateway_client) = setup_gateway(&env, 0, 5);
     let source_app = setup_app(&env, &source_gateway_client.address);
 
     // Setup destination Axelar gateway
     let destination_chain = String::from_str(&env, "destination");
-    let (destination_gateway_client, signers) = setup_gateway(&env);
+    let (signers, destination_gateway_client) = setup_gateway(&env, 0, 5);
     let destination_gateway_id = destination_gateway_client.address.clone();
     let destination_app = setup_app(&env, &destination_gateway_id);
     let destination_app_id = destination_app.address.clone();

--- a/integration-tests/tests/gmp.rs
+++ b/integration-tests/tests/gmp.rs
@@ -1,11 +1,9 @@
 use axelar_gateway::testutils::{generate_proof, get_approve_hash, initialize, TestSignerSet};
 use axelar_gateway::types::Message;
-use axelar_gateway::{AxelarGatewayClient};
+use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::assert_last_emitted_event;
 use soroban_sdk::{contract, contractimpl, log, Bytes, Symbol};
-use soroban_sdk::{
-    testutils::Address as _, testutils::BytesN as _, vec, Address, BytesN, Env, String,
-};
+use soroban_sdk::{testutils::BytesN as _, vec, Address, BytesN, Env, String};
 
 use axelar_gateway::executable::AxelarExecutableInterface;
 

--- a/integration-tests/tests/upgrade.rs
+++ b/integration-tests/tests/upgrade.rs
@@ -31,13 +31,7 @@ fn upgrade() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let gateway_id = env.register_contract_wasm(None, old_contract::WASM);
-    let gateway_client = AxelarGatewayClient::new(&env, &gateway_id);
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-
-    initialize(&env, &gateway_client, owner, operator, 0, 5);
-
+    let (_signers, gateway_id) = initialize(&env, 0, 5);
     let client = old_contract::Client::new(&env, &gateway_id);
 
     assert_eq!(

--- a/integration-tests/tests/upgrade.rs
+++ b/integration-tests/tests/upgrade.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use axelar_gateway::testutils::initialize;
+use axelar_gateway::testutils::setup_gateway;
 
 use soroban_sdk::{Env, String};
 
@@ -30,8 +30,7 @@ fn upgrade() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (_signers, gateway_id) = initialize(&env, 0, 5);
-    let client = old_contract::Client::new(&env, &gateway_id);
+    let (_signers, client) = setup_gateway(&env, 0, 5);
 
     assert_eq!(
         String::from_str(&env, OLD_CONTRACT_VERSION),

--- a/integration-tests/tests/upgrade.rs
+++ b/integration-tests/tests/upgrade.rs
@@ -2,8 +2,7 @@
 
 use axelar_gateway::testutils::initialize;
 
-use axelar_gateway::AxelarGatewayClient;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{Env, String};
 
 // For reproducibility:
 // 1. Update the package version in Cargo.toml to reflect new changes.


### PR DESCRIPTION
closes https://axelarnetwork.atlassian.net/browse/AXE-6581

## Summary

similar to #69

most of the changes are to the tests

- `testutils::initialize` now returns the `contract_id` it generated since it doesn't depend on a `client` anymore (`contract_id` is needed  to make a `client`) 
- remove instances of initializing after setup_env (they are handled in `setup_env` now)
   - setup_env now requires passing in values for `num_signers` and `minimum_rotation_delay`. Where there was not already a value defined (i.e. tests that did not require initializing), defaulted to `setup_env(1, 5)`
- setup_env in `auth.rs` and `tests/test.rs` doesn't return `contract_id`, instead prefer using `client.address` where possible
- update `validate_message` to expect 1 event because of the event emitted while initializing