### PR TITLE
temp: use contractimport to resolve symbol multiply defined

### DIFF
--- a/contracts/example/src/contract.rs
+++ b/contracts/example/src/contract.rs
@@ -1,12 +1,26 @@
 use crate::event;
-use axelar_gas_service::AxelarGasServiceClient;
-use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::types::Token;
 use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, String};
 
 use crate::storage_types::DataKey;
 
-use axelar_gateway::executable::AxelarExecutableInterface;
+mod axelar_gateway {
+    soroban_sdk::contractimport!(
+        file =
+            "../../../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gateway.wasm"
+    );
+}
+
+mod axelar_gas_service {
+    soroban_sdk::contractimport!(
+        file =
+            "../../../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gas_service.wasm"
+    );
+}
+
+use ::axelar_gas_service::AxelarGasServiceClient;
+use ::axelar_gateway::executable::AxelarExecutableInterface;
+use ::axelar_gateway::AxelarGatewayClient;
 
 #[contract]
 pub struct Example;


### PR DESCRIPTION
A temporary Draft PR:

use contractimport! to resolve symbol multiply defined! error

```
warning: Linking globals named '__constructor': symbol multiply defined!

error: failed to load bitcode of module "axelar_gas_service.axelar_gas_service.d59112ce369b540f-cgu.0.rcgu.o": 

warning: `example` (lib) generated 1 warning
error: could not compile `example` (lib) due to 1 previous error; 1 warning emitted
❌ error: exit status exit status: 101

```