### PR TITLE
feat: allow exporting soroban contract crates are libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ name = "axelar-gas-service"
 version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
+ "cfg-if",
  "soroban-sdk",
 ]
 
@@ -181,6 +182,7 @@ name = "axelar-gateway"
 version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
+ "cfg-if",
  "ed25519-dalek",
  "goldie",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.81.0"
 
 [workspace.dependencies]
 soroban-sdk = { version = "22.0.0-rc.3" }
+cfg-if = { version = "1.0" }
 axelar-soroban-std = { version = "^0.1.0", path = "packages/axelar-soroban-std" }
 axelar-gas-service = { version = "^0.1.0", path = "contracts/axelar-gas-service" }
 axelar-gateway = { version = "^0.1.0", path = "contracts/axelar-gateway" }

--- a/contracts/axelar-gas-service/Cargo.toml
+++ b/contracts/axelar-gas-service/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 axelar-soroban-std = { workspace = true }
-soroban-sdk = { workspace = true }
 cfg-if = { workspace = true }
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }

--- a/contracts/axelar-gas-service/Cargo.toml
+++ b/contracts/axelar-gas-service/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 axelar-soroban-std = { workspace = true }
 soroban-sdk = { workspace = true }
+cfg-if = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }
@@ -19,3 +20,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]
 workspace = true
+
+[features]
+library = [] # Only export the contract interface
+testutils = []

--- a/contracts/axelar-gas-service/src/interface.rs
+++ b/contracts/axelar-gas-service/src/interface.rs
@@ -1,0 +1,42 @@
+use axelar_soroban_std::types::Token;
+use soroban_sdk::{contractclient, Address, Bytes, Env, String};
+
+use crate::error::ContractError;
+
+#[contractclient(name = "AxelarGasServiceClient")]
+pub trait AxelarGasServiceInterface {
+    /// Pay for gas using a token for a contract call on a destination chain.
+    ///
+    /// This function is called on the source chain before calling the gateway to execute a remote contract.
+    fn pay_gas_for_contract_call(
+        env: Env,
+        sender: Address,
+        destination_chain: String,
+        destination_address: String,
+        payload: Bytes,
+        refund_address: Address,
+        token: Token,
+    ) -> Result<(), ContractError>;
+
+    /// Add additional gas payment after initiating a cross-chain call.
+    fn add_gas(
+        env: Env,
+        sender: Address,
+        message_id: String,
+        token: Token,
+        refund_address: Address,
+    ) -> Result<(), ContractError>;
+
+    /// Allows the `gas_collector` to collect accumulated fees from the contract.
+    ///
+    /// Only callable by the `gas_collector`.
+    fn collect_fees(env: Env, receiver: Address, token: Token) -> Result<(), ContractError>;
+
+    /// Refunds gas payment to the receiver in relation to a specific cross-chain transaction.
+    ///
+    /// Only callable by the `gas_collector`.
+    fn refund(env: Env, message_id: String, receiver: Address, token: Token);
+
+    /// Returns the address of the `gas_collector`.
+    fn gas_collector(env: &Env) -> Address;
+}

--- a/contracts/axelar-gas-service/src/lib.rs
+++ b/contracts/axelar-gas-service/src/lib.rs
@@ -1,9 +1,20 @@
 #![no_std]
 
-mod event;
-mod storage_types;
-
-pub mod contract;
 pub mod error;
 
-pub use contract::AxelarGasServiceClient;
+mod interface;
+
+#[cfg(all(target_family = "wasm", feature = "testutils"))]
+compile_error!("'testutils' feature is not supported on 'wasm' target");
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "library", not(feature = "testutils")))] {
+        pub use interface::{AxelarGasServiceClient, AxelarGasServiceInterface};
+    } else {
+        mod event;
+        mod storage_types;
+
+        pub mod contract;
+        pub use contract::{AxelarGasService, AxelarGasServiceClient};
+    }
+}

--- a/contracts/axelar-gateway/Cargo.toml
+++ b/contracts/axelar-gateway/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 axelar-soroban-std = { workspace = true }
+cfg-if = { workspace = true }
 ed25519-dalek = { version = "^2.1", default-features = false, optional = true }
 rand = { version = "0.8.5", optional = true }
 soroban-sdk = { workspace = true }
-cfg-if = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }

--- a/contracts/axelar-gateway/Cargo.toml
+++ b/contracts/axelar-gateway/Cargo.toml
@@ -14,6 +14,7 @@ axelar-soroban-std = { workspace = true }
 ed25519-dalek = { version = "^2.1", default-features = false, optional = true }
 rand = { version = "0.8.5", optional = true }
 soroban-sdk = { workspace = true }
+cfg-if = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }
@@ -25,6 +26,7 @@ rand = { version = "0.8.5" }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [features]
+library = [] # Only export the contract interface
 testutils = ["soroban-sdk/testutils", "axelar-soroban-std/testutils", "ed25519-dalek", "rand"]
 
 [lints]

--- a/contracts/axelar-gateway/src/contract.rs
+++ b/contracts/axelar-gateway/src/contract.rs
@@ -224,7 +224,7 @@ impl AxelarGatewayInterface for AxelarGateway {
     }
 
     fn version(env: &Env) -> String {
-        String::from_str(&env, CONTRACT_VERSION)
+        String::from_str(env, CONTRACT_VERSION)
     }
 
     fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {

--- a/contracts/axelar-gateway/src/interface.rs
+++ b/contracts/axelar-gateway/src/interface.rs
@@ -1,0 +1,96 @@
+use soroban_sdk::{contractclient, Address, Bytes, BytesN, Env, String, Vec};
+
+use crate::{
+    error::ContractError,
+    types::{Message, Proof, WeightedSigners},
+};
+
+#[contractclient(name = "AxelarGatewayClient")]
+pub trait AxelarGatewayInterface {
+    /// Sends a message to the specified destination chain and contarct address with a given payload.
+    ///
+    /// This function is the entry point for general message passing between chains.
+    ///
+    /// A registered chain name on Axelar must be used for `destination_chain`.
+    fn call_contract(
+        env: Env,
+        caller: Address,
+        destination_chain: String,
+        destination_address: String,
+        payload: Bytes,
+    );
+
+    /// Checks if a message is approved
+    ///
+    /// Determines whether a given message, identified by its `source_chain` and `message_id`, is approved.
+    ///
+    /// Returns true if a message with the given `payload_hash`  is approved.
+    fn is_message_approved(
+        env: Env,
+        source_chain: String,
+        message_id: String,
+        source_address: String,
+        contract_address: Address,
+        payload_hash: BytesN<32>,
+    ) -> bool;
+
+    /// Checks if a message is executed.
+    ///
+    /// Returns true if the message is executed, false otherwise.
+    fn is_message_executed(env: Env, source_chain: String, message_id: String) -> bool;
+
+    /// Validates if a message is approved. If message was in approved status, status is updated to executed to avoid
+    /// replay.
+    ///
+    /// `caller` must be the intended `destination_address` of the contract call for validation to succeed.
+    fn validate_message(
+        env: Env,
+        caller: Address,
+        source_chain: String,
+        message_id: String,
+        source_address: String,
+        payload_hash: BytesN<32>,
+    ) -> bool;
+
+    /// Approves a collection of messages.
+    fn approve_messages(
+        env: Env,
+        messages: Vec<Message>,
+        proof: Proof,
+    ) -> Result<(), ContractError>;
+
+    // TODO: add docstring about how bypass_rotation_delay supposed to be used.
+    fn rotate_signers(
+        env: Env,
+        signers: WeightedSigners,
+        proof: Proof,
+        bypass_rotation_delay: bool,
+    ) -> Result<(), ContractError>;
+
+    /// Transfers operatorship of the gateway to a new address.
+    fn transfer_operatorship(env: Env, new_operator: Address);
+
+    /// Returns the operator address of the gateway.
+    fn operator(env: &Env) -> Address;
+
+    /// Returns the epoch of the gateway.
+    fn epoch(env: &Env) -> u64;
+
+    /// Returns the version of the gateway.
+    fn version(env: &Env) -> String;
+
+    /// Upgrades the gateway to a new wasm hash.
+    fn upgrade(env: Env, new_wasm_hash: BytesN<32>);
+
+    /// Transfers ownership of the gateway to a new address.
+    fn transfer_ownership(env: Env, new_owner: Address);
+
+    /// Returns the owner address of the gateway.
+    fn owner(env: &Env) -> Address;
+
+    /// Returns the epoch by signers hash.
+    fn epoch_by_signers_hash(env: &Env, signers_hash: BytesN<32>) -> Result<u64, ContractError>;
+
+    /// Returns the signers hash by epoch.
+    fn signers_hash_by_epoch(env: &Env, epoch: u64) -> Result<BytesN<32>, ContractError>;
+}

--- a/contracts/axelar-gateway/src/lib.rs
+++ b/contracts/axelar-gateway/src/lib.rs
@@ -1,23 +1,31 @@
 #![no_std]
 
-mod auth;
-mod event;
-mod storage_types;
-
-pub mod contract;
-pub mod error;
-pub mod executable;
-pub mod types;
-
-#[cfg(all(target_family = "wasm", feature = "testutils"))]
-compile_error!("'testutils' feature is not supported on 'wasm' target");
-
-#[cfg(any(test, feature = "testutils"))]
-pub mod testutils;
-
 // Allows using std (and its macros) in test modules
 #[cfg(test)]
 #[macro_use]
 extern crate std;
 
-pub use contract::{AxelarGateway, AxelarGatewayClient};
+pub mod error;
+pub mod types;
+
+pub mod executable;
+mod interface;
+
+#[cfg(all(target_family = "wasm", feature = "testutils"))]
+compile_error!("'testutils' feature is not supported on 'wasm' target");
+
+#[cfg(feature = "testutils")]
+pub mod testutils;
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "library", not(feature = "testutils")))] {
+        pub use interface::{AxelarGatewayClient, AxelarGatewayInterface};
+    } else {
+        mod auth;
+        mod event;
+        mod storage_types;
+
+        pub mod contract;
+        pub use contract::{AxelarGateway, AxelarGatewayClient};
+    }
+}

--- a/contracts/axelar-gateway/src/testutils.rs
+++ b/contracts/axelar-gateway/src/testutils.rs
@@ -32,9 +32,9 @@ pub fn setup_gateway<'a>(
     previous_signers_retention: u32,
     num_signers: u32,
 ) -> (TestSignerSet, AxelarGatewayClient<'a>) {
-    let owner = Address::generate(&env);
-    let operator = Address::generate(&env);
-    let signer_set = generate_signers_set(&env, num_signers, BytesN::random(&env));
+    let owner = Address::generate(env);
+    let operator = Address::generate(env);
+    let signer_set = generate_signers_set(env, num_signers, BytesN::random(env));
     let initial_signers = vec![&env, signer_set.signers.clone()];
     let minimum_rotation_delay: u64 = 0;
 
@@ -50,7 +50,7 @@ pub fn setup_gateway<'a>(
         ),
     );
 
-    let client = AxelarGatewayClient::new(&env, &contract_id);
+    let client = AxelarGatewayClient::new(env, &contract_id);
     (signer_set, client)
 }
 
@@ -188,7 +188,7 @@ pub fn rotate_signers(env: &Env, contract_id: &Address, new_signers: TestSignerS
         env,
         contract_id,
         (
-            Symbol::new(&env, "signers_rotated"),
+            Symbol::new(env, "signers_rotated"),
             epoch_val,
             new_signers.signers.hash(env),
         ),

--- a/contracts/axelar-gateway/tests/test.rs
+++ b/contracts/axelar-gateway/tests/test.rs
@@ -99,10 +99,10 @@ fn validate_message() {
         "validate_message",
         (
             &contract_address,
-            source_chain.clone(),
-            message_id.clone(),
-            source_address.clone(),
-            payload_hash.clone(),
+            source_chain,
+            message_id,
+            source_address,
+            payload_hash,
         ),
     );
 
@@ -155,7 +155,7 @@ fn approve_message() {
     assert_last_emitted_event(
         &env,
         &client.address,
-        (Symbol::new(&env, "message_executed"), message.clone()),
+        (Symbol::new(&env, "message_executed"), message),
         (),
     );
 
@@ -179,7 +179,7 @@ fn fail_execute_invalid_proof() {
 
     let invalid_signers = generate_signers_set(&env, randint(1, 10), signers.domain_separator);
 
-    let messages = vec![&env, message.clone()];
+    let messages = vec![&env, message];
     let data_hash = get_approve_hash(&env, messages.clone());
     let proof = generate_proof(&env, data_hash, invalid_signers);
 
@@ -208,7 +208,7 @@ fn approve_messages_skip_duplicate_message() {
     let (env, signers, client) = setup_env(1, randint(1, 10));
     let (message, _) = generate_test_message(&env);
 
-    let messages = vec![&env, message.clone()];
+    let messages = vec![&env, message];
     let data_hash = get_approve_hash(&env, messages.clone());
     let proof = generate_proof(&env, data_hash, signers);
     client.approve_messages(&messages, &proof);
@@ -227,7 +227,7 @@ fn rotate_signers() {
 
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers);
+    let proof = generate_proof(&env, data_hash, signers);
     let bypass_rotation_delay = false;
     let new_epoch: u64 = client.epoch() + 1;
 
@@ -264,7 +264,7 @@ fn rotate_signers_bypass_rotation_delay() {
     let (env, signers, client) = setup_env(1, 5);
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers.clone());
+    let proof = generate_proof(&env, data_hash, signers);
     let bypass_rotation_delay = true;
     let new_epoch: u64 = client.epoch() + 1;
 
@@ -292,7 +292,7 @@ fn rotate_signers_bypass_rotation_delay_unauthorized() {
     let new_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
 
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers);
+    let proof = generate_proof(&env, data_hash, signers);
     let bypass_rotation_delay = true;
 
     assert_invoke_auth_err!(
@@ -315,12 +315,12 @@ fn rotate_signers_fail_not_latest_signers() {
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = first_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers.clone());
+    let proof = generate_proof(&env, data_hash, signers.clone());
     client.rotate_signers(&first_signers.signers, &proof, &bypass_rotation_delay);
 
     let second_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = second_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers.clone());
+    let proof = generate_proof(&env, data_hash, signers);
 
     assert_contract_err!(
         client.try_rotate_signers(&second_signers.signers, &proof, &bypass_rotation_delay),
@@ -342,7 +342,7 @@ fn transfer_operatorship() {
         &client.address,
         (
             Symbol::new(&env, "operatorship_transferred"),
-            operator.clone(),
+            operator,
             new_operator.clone(),
         ),
         (),
@@ -409,7 +409,7 @@ fn epoch_by_signers_hash() {
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = first_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers.clone());
+    let proof = generate_proof(&env, data_hash, signers);
 
     client.rotate_signers(&first_signers.signers, &proof, &bypass_rotation_delay);
 
@@ -438,7 +438,7 @@ fn signers_hash_by_epoch() {
 
     let first_signers = generate_signers_set(&env, 5, signers.domain_separator.clone());
     let data_hash = first_signers.signers.signers_rotation_hash(&env);
-    let proof = generate_proof(&env, data_hash.clone(), signers.clone());
+    let proof = generate_proof(&env, data_hash, signers);
 
     client.rotate_signers(&first_signers.signers, &proof, &bypass_rotation_delay);
     let epoch = client.epoch();

--- a/contracts/example/Cargo.toml
+++ b/contracts/example/Cargo.toml
@@ -7,12 +7,13 @@ edition = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-axelar-gas-service = { workspace = true }
-axelar-gateway = { workspace = true }
+axelar-gas-service = { workspace = true, features = ["library"] }
+axelar-gateway = { workspace = true, features = ["library"] }
 axelar-soroban-std = { workspace = true }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
+axelar-gas-service = { workspace = true, features = ["testutils"] }
 axelar-gateway = { workspace = true, features = ["testutils"] }
 axelar-soroban-std = { workspace = true, features = ["testutils"] }
 soroban-sdk = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
[AXE-6666]

This PR adds support for a `library` feature that allows soroban contracts to be exported as libraries, i.e without entrypoints to prevent issues with entrypoint name collisions.

`soroban contract build` now works without name collision issues.

## Notes

- A `testutils` feature is now also required, since Rust doesn't seem to allow declaring a dependency with `features = ["library"]` but a dev dependency with `features = []`, which I believe is because cargo features need to be additive (although need to dive more into). And the actual contract needs to be available in tests.
- Another consequence of this is that it enforces that private methods don't get included as contract entrypoints, since the trait implementation won't allow it
- The Interface trait can also extend other Interfaces (e.g. Upgradable, etc.)

[AXE-6666]: https://axelarnetwork.atlassian.net/browse/AXE-6666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ