### PR TITLE
fix(its): move ITS test directory to the correct level

### DIFF
--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -1,11 +1,9 @@
 use axelar_soroban_std::ensure;
-use soroban_sdk::{contract, contractimpl, /*symbol_short,*/ Address, Env, String, /*Symbol*/};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 use crate::error::ContractError;
 use crate::event;
 use crate::storage_types::DataKey;
-
-// const ITS_HUB_ROUTING_IDENTIFIER: Symbol = symbol_short!("hub");
 
 #[contract]
 pub struct InterchainTokenService;

--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -1,9 +1,11 @@
 use axelar_soroban_std::ensure;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, /*symbol_short,*/ Address, Env, String, /*Symbol*/};
 
 use crate::error::ContractError;
 use crate::event;
 use crate::storage_types::DataKey;
+
+// const ITS_HUB_ROUTING_IDENTIFIER: Symbol = symbol_short!("hub");
 
 #[contract]
 pub struct InterchainTokenService;

--- a/contracts/interchain-token-service/tests/test.rs
+++ b/contracts/interchain-token-service/tests/test.rs
@@ -1,5 +1,5 @@
-use crate::error::ContractError;
-use crate::{contract::InterchainTokenService, contract::InterchainTokenServiceClient};
+use interchain_token_service::contract::{InterchainTokenService, InterchainTokenServiceClient};
+use interchain_token_service::error::ContractError;
 
 use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event};
 use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};


### PR DESCRIPTION
`tests/` directory for ITS was at the wrong level of the file tree