### PR TITLE
docs: upload soroban docs to gh pages

### DIFF
--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,17 +29,10 @@ jobs:
         with:
           toolchain: 1.81.0
 
-      - name: Setup cargo cache
-        uses: actions/cache@v3
+      - name: Rust Cache
+        uses: useblacksmith/rust-cache@v3
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: "cache"
 
       - name: Build Documentation
         run: |

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docs/gh-pages
 
 permissions:
   contents: read

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -1,0 +1,76 @@
+name: Upload Docs
+
+on:
+  push:
+    branches:
+      - main
+      - docs/gh-pages
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.81.0
+
+      - name: Setup cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build Documentation
+        run: |
+          # Build docs for all workspace members
+          cargo doc --no-deps --workspace
+
+          # Create an index.html that redirects to the main crate's docs
+          echo '<meta http-equiv="refresh" content="0; url=axelar_gateway/index.html">' > target/doc/index.html
+
+          # Copy the generated docs to the pages directory
+          mkdir -p pages
+          cp -r target/doc/* pages/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages
+
+  deploy:
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repo implements Axelar's [cross-chain gateway protocol](https://github.com/
 
 > Check configuration for CLI and Identity before deployment: https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup
 
+## Docs
+
+Rustdocs for this workspace can be found [here](https://axelarnetwork.github.io/axelar-cgp-soroban).
+
 ## Install
 
 Install Soroban CLI

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo implements Axelar's [cross-chain gateway protocol](https://github.com/
 
 ## Docs
 
-Rustdocs for this workspace can be found [here](https://axelarnetwork.github.io/axelar-cgp-soroban).
+Rustdocs for this workspace can be found [here](https://axelarnetwork.github.io/axelar-cgp-soroban/).
 
 ## Install
 

--- a/packages/axelar-soroban-std/src/error.rs
+++ b/packages/axelar-soroban-std/src/error.rs
@@ -20,7 +20,7 @@ macro_rules! ensure {
 /// the [`Result`] is an [`Err`] then the macro will [`panic`]
 /// with a message that includes the expression and the error.
 ///
-/// This function was vendored from: https://docs.rs/assert_ok/1.0.2/assert_ok/
+/// This function was vendored from [assert_ok](https://docs.rs/assert_ok/1.0.2/assert_ok/).
 #[macro_export]
 macro_rules! assert_ok {
     ( $x:expr ) => {


### PR DESCRIPTION
[AXE-6854]
This PR adds a workflow to start deploying rust docs to github pages for this repo
https://axelarnetwork.github.io/axelar-cgp-soroban/

[AXE-6854]: https://axelarnetwork.atlassian.net/browse/AXE-6854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ