### PR TITLE
fix(github-workflows): contract-storage-diff hang

### DIFF
--- a/.github/workflows/contract-storage-diff.yaml
+++ b/.github/workflows/contract-storage-diff.yaml
@@ -1,9 +1,6 @@
 name: Contract Storage Schema Migration Check
 
-on:
-  pull_request:
-    paths:
-      - '**/*ensure_*_storage_schema_is_unchanged.golden'
+on: pull_request
 
 jobs:
   check-migration:


### PR DESCRIPTION
Addresses issue where the `contract-storage-diff` workflow would hang on `Expected — Waiting for status to be reported` if a `**/*ensure_*_storage_schema_is_unchanged.golden` was not present in the PR's diff.