### PR TITLE
chore: use pinned cargo sort version 1.0.9 for compatibility

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,6 +42,8 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-sort
+          # Pinned version for compatibility with Rust 1.81.0
+          version: 1.0.9
 
       - name: Run cargo sort
         run: cargo-sort --workspace --check --check-format


### PR DESCRIPTION
error message:
```
Installing cargo-sort...
  Fetching information for cargo-sort from index ...
  Installation settings:
     version: 2.0.1
     path: /home/runner/.cargo-install/cargo-sort
     key: cargo-install-cargo-sort-2.0.1-52c2507b04858c44e710
  Warning: Failed to restore: getCacheEntry failed: Cache service responded with 503
No cached version found, installing cargo-sort using cargo...
  /home/runner/.cargo/bin/cargo install cargo-sort --force --root /home/runner/.cargo-install/cargo-sort --version 2.0.1 --locked
      Updating crates.io index
   Downloading crates ...
    Downloaded cargo-sort v2.0.1
  error: cannot install package `cargo-sort 2.0.1`, it requires rustc 1.82 or newer, while the currently active rustc version is 1.81.0
  `cargo-sort 1.0.9` has an unspecified minimum rustc version
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
      at _ExecState._setResult (/home/runner/_work/_actions/baptiste0928/cargo-install/v2/dist/index.js:3122:22)
      at _ExecState.CheckComplete (/home/runner/_work/_actions/baptiste0928/cargo-install/v2/dist/index.js:3108:[16](https://github.com/axelarnetwork/axelar-amplifier-stellar/actions/runs/15641707004/job/44070757919?pr=347#step:8:17))
      at ChildProcess.<anonymous> (/home/runner/_work/_actions/baptiste0928/cargo-install/v2/dist/index.js:3011:21)
      at ChildProcess.emit (node:events:524:28)
      at maybeClose (node:internal/child_process:1104:16)
      at ChildProcess._handle.onexit (node:internal/child_process:304:5)
`