### PR TITLE
ci: pin actions/create-github-app-token to commit SHA

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -44,7 +44,7 @@ jobs:
           ref: ${{ steps.branch-check.outputs.branch_name }}
 
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/release-upload-to-r2.yaml
+++ b/.github/workflows/release-upload-to-r2.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/reusable-upload.yaml
+++ b/.github/workflows/reusable-upload.yaml
@@ -164,7 +164,7 @@ jobs:
       # Update the existing release and upload the wasm files, zip and tar archives to the specific tag
       # https://github.com/orgs/community/discussions/26263#discussioncomment-3251069
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         if: inputs.github-release
         with:


### PR DESCRIPTION
Pin the GitHub App token action to a commit SHA (v3.2.0) instead of the mutable v3 tag, matching the pinning convention used by the other actions in these workflows. The action receives the App's private key as input, so a tag-level supply chain attack would be high-impact.

Part of CPI-302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code risk but it touches multiple release workflows; a bad pin or upstream change could break token generation and thus block release/release-upload automation.
> 
> **Overview**
> Pins `actions/create-github-app-token` from the floating `@v3` tag to a specific commit SHA (`v3.2.0`) across the release-related GitHub Actions workflows.
> 
> This hardens the release pipelines against tag-mutation/supply-chain risk while keeping the workflows’ behavior otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860f74ee9c2a7d706a87812c87c7b447c20e7e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->