### PR TITLE
feat: add flow limiter role to its

### DIFF
--- a/.github/scripts/check-migration.sh
+++ b/.github/scripts/check-migration.sh
@@ -21,8 +21,38 @@ main() {
             continue
         fi
 
+        # Purely-additive schema changes (e.g. a new enum variant appended) leave
+        # all existing ledger keys untouched and cannot be migrated. Skip the
+        # migration requirement only when no existing lines were removed or
+        # modified. Any rename, field change, deletion, or formatting edit
+        # produces a '-' line in the diff and falls through to the strict check.
+        if is_additive_only "$1" "$2" "$file"; then
+            echo "✓ $file change is purely additive; migration not required"
+            continue
+        fi
+
         check_migration_file "$file"
     done <<< "$CHANGED_FILES"
+}
+
+# Returns 0 if the unified diff for $file between $base and $head contains no
+# removal lines, 1 otherwise. Pure additions (new lines only) cannot break
+# existing storage and so do not need a migration.
+is_additive_only() {
+    local base="$1"
+    local head="$2"
+    local file="$3"
+
+    # Unified diff lines we care about:
+    #   '--- a/path' — file header (start of diff for this file) — ignore
+    #   '-content'   — removed line — disqualifies an additive-only change
+    #   '+content'   — added line — fine
+    #   ' content'   — context line — fine
+    # Match any '-' prefixed line and exclude the '---' file header.
+    local removed_lines
+    removed_lines=$(git diff --no-ext-diff "$base" "$head" -- "$file" | grep -E '^-' | grep -vE '^---' || true)
+
+    [ -z "$removed_lines" ]
 }
 
 check_migration_file() {

--- a/contracts/stellar-interchain-token-service/CHANGELOG.md
+++ b/contracts/stellar-interchain-token-service/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⛰️ Features
 
-- *(interchain-token-service)* Add per-token flow limiter role. The contract operator can `add_flow_limiter`, `remove_flow_limiter`, and `transfer_flow_limiter` per `token_id`. Approved flow limiters can call `set_flow_limit` for their token in addition to the operator.
-
-### ⚠ BREAKING CHANGES
-
-- *(interchain-token-service)* `set_flow_limit` now takes a `caller: Address` as its first parameter. `caller` must authorize and must be either the contract operator or an approved flow limiter for the given `token_id`.
+- *(interchain-token-service)* Add per-token flow limiter role. The contract operator can `add_flow_limiter`, `remove_flow_limiter`, and `transfer_flow_limiter` per `token_id`. Approved flow limiters can call `set_flow_limit` for their token in addition to the operator. Note: `set_flow_limit` now takes an additional leading `caller: Address` parameter — callers must update their call sites accordingly.
 
 ## [2.0.0](https://github.com/axelarnetwork/axelar-amplifier-stellar/compare/stellar-interchain-token-service-v1.4.1...stellar-interchain-token-service-v2.0.0)
 

--- a/contracts/stellar-interchain-token-service/CHANGELOG.md
+++ b/contracts/stellar-interchain-token-service/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⛰️ Features
 
-- *(interchain-token-service)* Add per-token flow limiter role. The contract operator can `add_flow_limiter`, `remove_flow_limiter`, and `transfer_flow_limiter` per `token_id`. Approved flow limiters can call `set_flow_limit` for their token in addition to the operator. Note: `set_flow_limit` now takes an additional leading `caller: Address` parameter — callers must update their call sites accordingly.
+- [**breaking**] *(interchain-token-service)* Add per-token flow limiter role. The contract operator can `add_flow_limiter`, `remove_flow_limiter`, and `transfer_flow_limiter` per `token_id`. Approved flow limiters can call `set_flow_limit` for their token in addition to the operator. `set_flow_limit` signature now takes a leading `caller: Address` parameter; callers must update their call sites accordingly.
 
 ## [2.0.0](https://github.com/axelarnetwork/axelar-amplifier-stellar/compare/stellar-interchain-token-service-v1.4.1...stellar-interchain-token-service-v2.0.0)
 

--- a/contracts/stellar-interchain-token-service/CHANGELOG.md
+++ b/contracts/stellar-interchain-token-service/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⛰️ Features
+
+- *(interchain-token-service)* Add per-token flow limiter role. The contract operator can `add_flow_limiter`, `remove_flow_limiter`, and `transfer_flow_limiter` per `token_id`. Approved flow limiters can call `set_flow_limit` for their token in addition to the operator.
+
+### ⚠ BREAKING CHANGES
+
+- *(interchain-token-service)* `set_flow_limit` now takes a `caller: Address` as its first parameter. `caller` must authorize and must be either the contract operator or an approved flow limiter for the given `token_id`.
+
 ## [2.0.0](https://github.com/axelarnetwork/axelar-amplifier-stellar/compare/stellar-interchain-token-service-v1.4.1...stellar-interchain-token-service-v2.0.0)
 
 ### ⛰️ Features

--- a/contracts/stellar-interchain-token-service/src/contract.rs
+++ b/contracts/stellar-interchain-token-service/src/contract.rs
@@ -17,9 +17,10 @@ use token_id::UnregisteredTokenId;
 
 use crate::error::ContractError;
 use crate::event::{
-    InterchainTokenDeploymentStartedEvent, InterchainTransferReceivedEvent,
-    InterchainTransferSentEvent, LinkTokenReceivedEvent, LinkTokenStartedEvent,
-    TokenMetadataRegisteredEvent, TrustedChainRemovedEvent, TrustedChainSetEvent,
+    FlowLimiterAddedEvent, FlowLimiterRemovedEvent, InterchainTokenDeploymentStartedEvent,
+    InterchainTransferReceivedEvent, InterchainTransferSentEvent, LinkTokenReceivedEvent,
+    LinkTokenStartedEvent, TokenMetadataRegisteredEvent, TrustedChainRemovedEvent,
+    TrustedChainSetEvent,
 };
 use crate::flow_limit::FlowDirection;
 use crate::interface::InterchainTokenServiceInterface;
@@ -171,13 +172,103 @@ impl InterchainTokenServiceInterface for InterchainTokenService {
         flow_limit::flow_in_amount(env, token_id)
     }
 
-    #[only_operator]
+    fn is_flow_limiter(env: &Env, token_id: BytesN<32>, flow_limiter: Address) -> bool {
+        storage::is_flow_limiter(env, token_id, flow_limiter)
+    }
+
     fn set_flow_limit(
         env: &Env,
+        caller: Address,
         token_id: BytesN<32>,
         flow_limit: Option<i128>,
     ) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        ensure!(
+            caller == Self::operator(env)
+                || storage::is_flow_limiter(env, token_id.clone(), caller),
+            ContractError::NotApprovedFlowLimiter
+        );
+
         flow_limit::set_flow_limit(env, token_id, flow_limit)
+    }
+
+    #[only_operator]
+    fn add_flow_limiter(
+        env: &Env,
+        token_id: BytesN<32>,
+        flow_limiter: Address,
+    ) -> Result<(), ContractError> {
+        ensure!(
+            !storage::is_flow_limiter(env, token_id.clone(), flow_limiter.clone()),
+            ContractError::FlowLimiterAlreadySet
+        );
+
+        storage::set_flow_limiter_status(env, token_id.clone(), flow_limiter.clone());
+
+        FlowLimiterAddedEvent {
+            token_id,
+            flow_limiter,
+        }
+        .emit(env);
+
+        Ok(())
+    }
+
+    #[only_operator]
+    fn remove_flow_limiter(
+        env: &Env,
+        token_id: BytesN<32>,
+        flow_limiter: Address,
+    ) -> Result<(), ContractError> {
+        ensure!(
+            storage::is_flow_limiter(env, token_id.clone(), flow_limiter.clone()),
+            ContractError::FlowLimiterNotSet
+        );
+
+        storage::remove_flow_limiter_status(env, token_id.clone(), flow_limiter.clone());
+
+        FlowLimiterRemovedEvent {
+            token_id,
+            flow_limiter,
+        }
+        .emit(env);
+
+        Ok(())
+    }
+
+    #[only_operator]
+    fn transfer_flow_limiter(
+        env: &Env,
+        token_id: BytesN<32>,
+        from: Address,
+        to: Address,
+    ) -> Result<(), ContractError> {
+        ensure!(
+            storage::is_flow_limiter(env, token_id.clone(), from.clone()),
+            ContractError::FlowLimiterNotSet
+        );
+        ensure!(
+            !storage::is_flow_limiter(env, token_id.clone(), to.clone()),
+            ContractError::FlowLimiterAlreadySet
+        );
+
+        storage::remove_flow_limiter_status(env, token_id.clone(), from.clone());
+        storage::set_flow_limiter_status(env, token_id.clone(), to.clone());
+
+        FlowLimiterRemovedEvent {
+            token_id: token_id.clone(),
+            flow_limiter: from,
+        }
+        .emit(env);
+
+        FlowLimiterAddedEvent {
+            token_id,
+            flow_limiter: to,
+        }
+        .emit(env);
+
+        Ok(())
     }
 
     #[when_not_paused]

--- a/contracts/stellar-interchain-token-service/src/error.rs
+++ b/contracts/stellar-interchain-token-service/src/error.rs
@@ -40,4 +40,7 @@ pub enum ContractError {
     FlowAmountExceededLimit = 34,
     InvalidTokenManagerType = 35,
     InvalidDestinationTokenAddress = 36,
+    FlowLimiterAlreadySet = 37,
+    FlowLimiterNotSet = 38,
+    NotApprovedFlowLimiter = 39,
 }

--- a/contracts/stellar-interchain-token-service/src/event.rs
+++ b/contracts/stellar-interchain-token-service/src/event.rs
@@ -22,6 +22,18 @@ pub struct FlowLimitSetEvent {
 }
 
 #[derive(Debug, PartialEq, Eq, IntoEvent)]
+pub struct FlowLimiterAddedEvent {
+    pub token_id: BytesN<32>,
+    pub flow_limiter: Address,
+}
+
+#[derive(Debug, PartialEq, Eq, IntoEvent)]
+pub struct FlowLimiterRemovedEvent {
+    pub token_id: BytesN<32>,
+    pub flow_limiter: Address,
+}
+
+#[derive(Debug, PartialEq, Eq, IntoEvent)]
 pub struct InterchainTokenDeployedEvent {
     pub token_id: BytesN<32>,
     pub token_address: Address,

--- a/contracts/stellar-interchain-token-service/src/interface.rs
+++ b/contracts/stellar-interchain-token-service/src/interface.rs
@@ -122,6 +122,9 @@ pub trait InterchainTokenServiceInterface:
     /// for the token associated with the specified token ID.
     fn flow_in_amount(env: &Env, token_id: BytesN<32>) -> i128;
 
+    /// Returns whether the given address is an approved flow limiter for the specified token.
+    fn is_flow_limiter(env: &Env, token_id: BytesN<32>, flow_limiter: Address) -> bool;
+
     /// Sets or updates the flow limit for a token.
     ///
     /// Flow limit controls how many tokens can flow in/out during a single epoch.
@@ -129,18 +132,70 @@ pub trait InterchainTokenServiceInterface:
     /// Setting the limit to 0 effectively freezes the token by preventing any flow.
     ///
     /// # Arguments
+    /// - `caller`: The address invoking the call. Must be either the contract operator or an
+    ///   approved flow limiter for the specified `token_id`.
     /// - `token_id`: Unique identifier of the token.
     /// - `flow_limit`: The new flow limit value. Must be positive if Some.
     ///
     /// # Errors
     /// - [`ContractError::InvalidFlowLimit`]: If the provided flow limit is not positive.
+    /// - [`ContractError::NotApprovedFlowLimiter`]: If `caller` is neither the operator nor an
+    ///   approved flow limiter for the token.
+    ///
+    /// # Authorization
+    /// - `caller` must authorize.
+    fn set_flow_limit(
+        env: &Env,
+        caller: Address,
+        token_id: BytesN<32>,
+        flow_limit: Option<i128>,
+    ) -> Result<(), ContractError>;
+
+    /// Adds an approved flow limiter for the specified token.
+    ///
+    /// Approved flow limiters can call [`Self::set_flow_limit`] for that token, in addition to
+    /// the contract operator.
+    ///
+    /// # Errors
+    /// - [`ContractError::FlowLimiterAlreadySet`]: If the address is already an approved flow
+    ///   limiter for the token.
     ///
     /// # Authorization
     /// - [`OperatableInterface::operator`] must authorize.
-    fn set_flow_limit(
+    fn add_flow_limiter(
         env: &Env,
         token_id: BytesN<32>,
-        flow_limit: Option<i128>,
+        flow_limiter: Address,
+    ) -> Result<(), ContractError>;
+
+    /// Removes an approved flow limiter for the specified token.
+    ///
+    /// # Errors
+    /// - [`ContractError::FlowLimiterNotSet`]: If the address is not an approved flow limiter
+    ///   for the token.
+    ///
+    /// # Authorization
+    /// - [`OperatableInterface::operator`] must authorize.
+    fn remove_flow_limiter(
+        env: &Env,
+        token_id: BytesN<32>,
+        flow_limiter: Address,
+    ) -> Result<(), ContractError>;
+
+    /// Atomically transfers the approved flow limiter role from `from` to `to` for the
+    /// specified token.
+    ///
+    /// # Errors
+    /// - [`ContractError::FlowLimiterNotSet`]: If `from` is not an approved flow limiter.
+    /// - [`ContractError::FlowLimiterAlreadySet`]: If `to` is already an approved flow limiter.
+    ///
+    /// # Authorization
+    /// - [`OperatableInterface::operator`] must authorize.
+    fn transfer_flow_limiter(
+        env: &Env,
+        token_id: BytesN<32>,
+        from: Address,
+        to: Address,
     ) -> Result<(), ContractError>;
 
     /// Deploys a new interchain token on the current chain with specified metadata and optional

--- a/contracts/stellar-interchain-token-service/src/storage.rs
+++ b/contracts/stellar-interchain-token-service/src/storage.rs
@@ -44,6 +44,13 @@ enum DataKey {
     #[value(i128)]
     FlowLimit { token_id: BytesN<32> },
 
+    #[persistent]
+    #[status]
+    FlowLimiter {
+        token_id: BytesN<32>,
+        flow_limiter: Address,
+    },
+
     #[temporary]
     #[value(i128)]
     FlowOut { token_id: BytesN<32>, epoch: u64 },

--- a/contracts/stellar-interchain-token-service/src/testdata/ensure_data_key_storage_schema_is_unchanged.golden
+++ b/contracts/stellar-interchain-token-service/src/testdata/ensure_data_key_storage_schema_is_unchanged.golden
@@ -40,6 +40,10 @@ enum DataKey {
     #[value(i128)]
     FlowLimit { token_id: BytesN<32> },
 
+    #[persistent]
+    #[status]
+    FlowLimiter { token_id: BytesN<32>, flow_limiter: Address },
+
     #[temporary]
     #[value(i128)]
     FlowOut { token_id: BytesN<32>, epoch: u64 },

--- a/contracts/stellar-interchain-token-service/src/tests/flow_limit.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/flow_limit.rs
@@ -66,9 +66,11 @@ fn setup<'a>() -> (
     let deployer = Address::generate(&env);
     let (token_id, _) = setup_its_token(&env, &client, &deployer, supply);
 
-    client
-        .mock_all_auths()
-        .set_flow_limit(&token_id, &Some(dummy_flow_limit()));
+    client.mock_all_auths().set_flow_limit(
+        &client.operator(),
+        &token_id,
+        &Some(dummy_flow_limit()),
+    );
 
     (
         env,
@@ -190,9 +192,11 @@ fn execute_test_case(
 ) {
     println!("Executing test case: {:?}", test_case);
 
-    client
-        .mock_all_auths()
-        .set_flow_limit(&token.id, &Some(test_case.flow_limit));
+    client.mock_all_auths().set_flow_limit(
+        &client.operator(),
+        &token.id,
+        &Some(test_case.flow_limit),
+    );
 
     let (destination_chain, destination_address, data) = dummy_transfer_params(env);
     let token_address = client.registered_token_address(&token.id);
@@ -269,9 +273,11 @@ fn set_flow_limit_succeeds() {
 
     assert_eq!(client.flow_limit(&token_id), None);
 
+    let operator = client.operator();
+
     assert_auth!(
-        client.operator(),
-        client.set_flow_limit(&token_id, &Some(dummy_flow_limit()))
+        &operator,
+        client.set_flow_limit(&operator, &token_id, &Some(dummy_flow_limit()))
     );
     goldie::assert!(events::fmt_last_emitted_event::<FlowLimitSetEvent>(&env));
 
@@ -284,9 +290,11 @@ fn set_flow_limit_to_none_succeeds() {
 
     assert_eq!(client.flow_limit(&token.id), Some(dummy_flow_limit()));
 
+    let operator = client.operator();
+
     assert_auth!(
-        client.operator(),
-        client.set_flow_limit(&token.id, &None::<i128>)
+        &operator,
+        client.set_flow_limit(&operator, &token.id, &None::<i128>)
     );
     goldie::assert!(events::fmt_last_emitted_event::<FlowLimitSetEvent>(&env));
 
@@ -303,8 +311,22 @@ fn set_flow_limit_fails_on_negative_limit() {
     assert_contract_err!(
         client
             .mock_all_auths()
-            .try_set_flow_limit(&token_id, &invalid_limit),
+            .try_set_flow_limit(&client.operator(), &token_id, &invalid_limit),
         ContractError::InvalidFlowLimit
+    );
+}
+
+#[test]
+fn set_flow_limit_fails_if_caller_not_authorized() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let stranger = Address::generate(&env);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_set_flow_limit(&stranger, &token_id, &Some(dummy_flow_limit())),
+        ContractError::NotApprovedFlowLimiter
     );
 }
 

--- a/contracts/stellar-interchain-token-service/src/tests/flow_limiter.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/flow_limiter.rs
@@ -1,0 +1,330 @@
+use std::format;
+
+use stellar_axelar_std::testutils::Address as _;
+use stellar_axelar_std::{
+    assert_auth, assert_auth_err, assert_contract_err, events, Address, BytesN,
+};
+
+use super::utils::setup_env;
+use crate::error::ContractError;
+use crate::event::{FlowLimiterAddedEvent, FlowLimiterRemovedEvent};
+
+const fn dummy_flow_limit() -> i128 {
+    1000
+}
+
+#[test]
+fn add_flow_limiter_succeeds() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    assert!(!client.is_flow_limiter(&token_id, &flow_limiter));
+
+    assert_auth!(
+        client.operator(),
+        client.add_flow_limiter(&token_id, &flow_limiter)
+    );
+
+    goldie::assert!(events::fmt_last_emitted_event::<FlowLimiterAddedEvent>(
+        &env
+    ));
+
+    assert!(client.is_flow_limiter(&token_id, &flow_limiter));
+}
+
+#[test]
+fn add_flow_limiter_fails_if_not_operator() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    let not_operator = Address::generate(&env);
+    assert_auth_err!(
+        not_operator,
+        client.add_flow_limiter(&token_id, &flow_limiter)
+    );
+    assert_auth_err!(
+        client.owner(),
+        client.add_flow_limiter(&token_id, &flow_limiter)
+    );
+}
+
+#[test]
+fn add_flow_limiter_fails_if_already_set() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_add_flow_limiter(&token_id, &flow_limiter),
+        ContractError::FlowLimiterAlreadySet
+    );
+}
+
+#[test]
+fn remove_flow_limiter_succeeds() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+    assert!(client.is_flow_limiter(&token_id, &flow_limiter));
+
+    assert_auth!(
+        client.operator(),
+        client.remove_flow_limiter(&token_id, &flow_limiter)
+    );
+
+    goldie::assert!(events::fmt_last_emitted_event::<FlowLimiterRemovedEvent>(
+        &env
+    ));
+
+    assert!(!client.is_flow_limiter(&token_id, &flow_limiter));
+}
+
+#[test]
+fn remove_flow_limiter_fails_if_not_operator() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+
+    let not_operator = Address::generate(&env);
+    assert_auth_err!(
+        not_operator,
+        client.remove_flow_limiter(&token_id, &flow_limiter)
+    );
+    assert_auth_err!(
+        client.owner(),
+        client.remove_flow_limiter(&token_id, &flow_limiter)
+    );
+}
+
+#[test]
+fn remove_flow_limiter_fails_if_not_set() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_remove_flow_limiter(&token_id, &flow_limiter),
+        ContractError::FlowLimiterNotSet
+    );
+}
+
+#[test]
+fn transfer_flow_limiter_succeeds() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    client.mock_all_auths().add_flow_limiter(&token_id, &from);
+
+    assert_auth!(
+        client.operator(),
+        client.transfer_flow_limiter(&token_id, &from, &to)
+    );
+
+    let removed = events::fmt_emitted_event_at_idx::<FlowLimiterRemovedEvent>(&env, -2);
+    let added = events::fmt_emitted_event_at_idx::<FlowLimiterAddedEvent>(&env, -1);
+    goldie::assert!(format!("{}\n---\n{}", removed, added));
+
+    assert!(!client.is_flow_limiter(&token_id, &from));
+    assert!(client.is_flow_limiter(&token_id, &to));
+}
+
+#[test]
+fn transfer_flow_limiter_fails_if_from_equals_to() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_transfer_flow_limiter(&token_id, &flow_limiter, &flow_limiter),
+        ContractError::FlowLimiterAlreadySet
+    );
+
+    assert!(client.is_flow_limiter(&token_id, &flow_limiter));
+}
+
+#[test]
+fn transfer_flow_limiter_fails_if_not_operator() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    client.mock_all_auths().add_flow_limiter(&token_id, &from);
+
+    let not_operator = Address::generate(&env);
+    assert_auth_err!(
+        not_operator,
+        client.transfer_flow_limiter(&token_id, &from, &to)
+    );
+}
+
+#[test]
+fn transfer_flow_limiter_fails_if_from_not_set() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_transfer_flow_limiter(&token_id, &from, &to),
+        ContractError::FlowLimiterNotSet
+    );
+}
+
+#[test]
+fn transfer_flow_limiter_fails_if_to_already_set() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    client.mock_all_auths().add_flow_limiter(&token_id, &from);
+    client.mock_all_auths().add_flow_limiter(&token_id, &to);
+
+    assert_contract_err!(
+        client
+            .mock_all_auths()
+            .try_transfer_flow_limiter(&token_id, &from, &to),
+        ContractError::FlowLimiterAlreadySet
+    );
+}
+
+#[test]
+fn approved_flow_limiter_can_set_flow_limit() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+
+    assert_auth!(
+        &flow_limiter,
+        client.set_flow_limit(&flow_limiter, &token_id, &Some(dummy_flow_limit()))
+    );
+
+    assert_eq!(client.flow_limit(&token_id), Some(dummy_flow_limit()));
+}
+
+#[test]
+fn removed_flow_limiter_cannot_set_flow_limit() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &flow_limiter);
+    client
+        .mock_all_auths()
+        .remove_flow_limiter(&token_id, &flow_limiter);
+
+    assert_contract_err!(
+        client.mock_all_auths().try_set_flow_limit(
+            &flow_limiter,
+            &token_id,
+            &Some(dummy_flow_limit())
+        ),
+        ContractError::NotApprovedFlowLimiter
+    );
+}
+
+#[test]
+fn multiple_flow_limiters_per_token() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id = BytesN::from_array(&env, &[1; 32]);
+    let limiter_a = Address::generate(&env);
+    let limiter_b = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &limiter_a);
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id, &limiter_b);
+
+    assert!(client.is_flow_limiter(&token_id, &limiter_a));
+    assert!(client.is_flow_limiter(&token_id, &limiter_b));
+
+    assert_auth!(
+        &limiter_a,
+        client.set_flow_limit(&limiter_a, &token_id, &Some(dummy_flow_limit()))
+    );
+    assert_eq!(client.flow_limit(&token_id), Some(dummy_flow_limit()));
+
+    assert_auth!(
+        &limiter_b,
+        client.set_flow_limit(&limiter_b, &token_id, &Some(dummy_flow_limit() * 2))
+    );
+    assert_eq!(client.flow_limit(&token_id), Some(dummy_flow_limit() * 2));
+
+    // Removing one does not affect the other
+    client
+        .mock_all_auths()
+        .remove_flow_limiter(&token_id, &limiter_a);
+
+    assert!(!client.is_flow_limiter(&token_id, &limiter_a));
+    assert!(client.is_flow_limiter(&token_id, &limiter_b));
+
+    assert_contract_err!(
+        client.mock_all_auths().try_set_flow_limit(
+            &limiter_a,
+            &token_id,
+            &Some(dummy_flow_limit())
+        ),
+        ContractError::NotApprovedFlowLimiter
+    );
+}
+
+#[test]
+fn flow_limiter_role_is_scoped_to_token_id() {
+    let (env, client, _, _, _) = setup_env();
+    let token_id_a = BytesN::from_array(&env, &[1; 32]);
+    let token_id_b = BytesN::from_array(&env, &[2; 32]);
+    let flow_limiter = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .add_flow_limiter(&token_id_a, &flow_limiter);
+
+    assert!(client.is_flow_limiter(&token_id_a, &flow_limiter));
+    assert!(!client.is_flow_limiter(&token_id_b, &flow_limiter));
+
+    assert_contract_err!(
+        client.mock_all_auths().try_set_flow_limit(
+            &flow_limiter,
+            &token_id_b,
+            &Some(dummy_flow_limit())
+        ),
+        ContractError::NotApprovedFlowLimiter
+    );
+}

--- a/contracts/stellar-interchain-token-service/src/tests/mod.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod deployer;
 mod executable;
 mod execute;
 mod flow_limit;
+mod flow_limiter;
 mod interchain_transfer;
 mod link_token;
 mod message_routing;

--- a/contracts/stellar-interchain-token-service/src/tests/testdata/add_flow_limiter_succeeds.golden
+++ b/contracts/stellar-interchain-token-service/src/tests/testdata/add_flow_limiter_succeeds.golden
@@ -1,0 +1,11 @@
+FlowLimiterAddedEvent {
+    token_id: BytesN<32>(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    flow_limiter: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N),
+}
+
+Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5)
+
+flow_limiter_added {
+    #[topic] token_id: BytesN < 32 >,
+    #[topic] flow_limiter: Address,
+}

--- a/contracts/stellar-interchain-token-service/src/tests/testdata/remove_flow_limiter_succeeds.golden
+++ b/contracts/stellar-interchain-token-service/src/tests/testdata/remove_flow_limiter_succeeds.golden
@@ -1,0 +1,11 @@
+FlowLimiterRemovedEvent {
+    token_id: BytesN<32>(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    flow_limiter: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N),
+}
+
+Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5)
+
+flow_limiter_removed {
+    #[topic] token_id: BytesN < 32 >,
+    #[topic] flow_limiter: Address,
+}

--- a/contracts/stellar-interchain-token-service/src/tests/testdata/transfer_flow_limiter_succeeds.golden
+++ b/contracts/stellar-interchain-token-service/src/tests/testdata/transfer_flow_limiter_succeeds.golden
@@ -1,0 +1,23 @@
+FlowLimiterRemovedEvent {
+    token_id: BytesN<32>(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    flow_limiter: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N),
+}
+
+Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5)
+
+flow_limiter_removed {
+    #[topic] token_id: BytesN < 32 >,
+    #[topic] flow_limiter: Address,
+}
+---
+FlowLimiterAddedEvent {
+    token_id: BytesN<32>(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    flow_limiter: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYRE5),
+}
+
+Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5)
+
+flow_limiter_added {
+    #[topic] token_id: BytesN < 32 >,
+    #[topic] flow_limiter: Address,
+}

--- a/packages/stellar-axelar-std-derive/src/contractstorage.rs
+++ b/packages/stellar-axelar-std-derive/src/contractstorage.rs
@@ -481,7 +481,7 @@ fn contract_storage_tests(r#enum: &Ident, enum_input: &DeriveInput) -> TokenStre
     );
 
     let enum_file: syn::File = syn::parse2(quote! { #enum_input }).unwrap();
-    let formatted_enum = unparse(&enum_file)
+    let formatted_enum = collapse_struct_variants(&unparse(&enum_file))
         .replace("    #[instance]", "\n    #[instance]")
         .replace("    #[persistent]", "\n    #[persistent]")
         .replace("    #[temporary]", "\n    #[temporary]");
@@ -497,6 +497,65 @@ fn contract_storage_tests(r#enum: &Ident, enum_input: &DeriveInput) -> TokenStre
             }
         }
     }
+}
+
+/// Collapses multi-line struct variants emitted by `prettyplease::unparse` into a
+/// single line per variant.
+///
+/// `prettyplease` wraps an enum variant's struct body onto multiple lines when the
+/// inline form exceeds its width limit. Without normalization, the
+/// `ensure_*_storage_schema_is_unchanged.golden` file would contain a mix of inline
+/// and multi-line variants, making purely-additive diff detection (used by
+/// `.github/scripts/check-migration.sh`) unreliable: adding a field to an existing
+/// multi-line variant would appear as a pure addition rather than a structural change.
+///
+/// Pre-conditions: assumes the input is the output of `prettyplease::unparse` on a
+/// single enum definition. A variant opener is recognized as a line indented by four
+/// spaces that ends with ` {`. Field lines have no nested braces (current storage
+/// enums never use const-generic or nested struct types inside variant fields).
+fn collapse_struct_variants(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut lines = input.lines();
+
+    while let Some(line) = lines.next() {
+        let is_variant_opener = line.starts_with("    ")
+            && line.trim_end().ends_with(" {")
+            && !line.trim_start().starts_with("enum ");
+
+        if !is_variant_opener {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        let mut collapsed = line.trim_end().to_string();
+        let mut fields: Vec<String> = Vec::new();
+
+        for inner in lines.by_ref() {
+            let trimmed = inner.trim();
+            if trimmed == "}" || trimmed == "}," {
+                if !fields.is_empty() {
+                    // `prettyplease` emits a trailing comma after each field in the
+                    // multi-line form; the inline form omits it on the last field.
+                    if let Some(last) = fields.last_mut() {
+                        if let Some(stripped) = last.strip_suffix(',') {
+                            *last = stripped.to_string();
+                        }
+                    }
+                    collapsed.push(' ');
+                    collapsed.push_str(&fields.join(" "));
+                }
+                collapsed.push(' ');
+                collapsed.push_str(trimmed);
+                break;
+            }
+            fields.push(trimmed.to_string());
+        }
+
+        out.push_str(&collapsed);
+        out.push('\n');
+    }
+    out
 }
 
 /// Tests the storage schema generation for a storage enum.
@@ -569,6 +628,32 @@ mod tests {
         };
 
         crate::contractstorage::contract_storage(&input);
+    }
+
+    #[test]
+    fn collapse_struct_variants_inlines_multiline_variant() {
+        let input = "enum DataKey {\n    Foo {\n        a: A,\n        b: B,\n    },\n}\n";
+        let expected = "enum DataKey {\n    Foo { a: A, b: B },\n}\n";
+        assert_eq!(super::collapse_struct_variants(input), expected);
+    }
+
+    #[test]
+    fn collapse_struct_variants_preserves_inline_variants() {
+        let input = "enum DataKey {\n    Foo { a: A, b: B },\n    Bar,\n}\n";
+        assert_eq!(super::collapse_struct_variants(input), input);
+    }
+
+    #[test]
+    fn collapse_struct_variants_handles_mixed_variants() {
+        let input = "enum DataKey {\n    Unit,\n    InlineStruct { x: u32 },\n    Multi {\n        long_field_a: VeryLongTypeName,\n        long_field_b: AnotherLongType,\n    },\n}\n";
+        let expected = "enum DataKey {\n    Unit,\n    InlineStruct { x: u32 },\n    Multi { long_field_a: VeryLongTypeName, long_field_b: AnotherLongType },\n}\n";
+        assert_eq!(super::collapse_struct_variants(input), expected);
+    }
+
+    #[test]
+    fn collapse_struct_variants_does_not_touch_enum_opener() {
+        let input = "enum DataKey {\n    Unit,\n}\n";
+        assert_eq!(super::collapse_struct_variants(input), input);
     }
 
     #[test]


### PR DESCRIPTION
Fixes CPI-293

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new authorization paths and persistent storage keys for flow-limit management in the ITS contract, which can affect who is permitted to change rate limits and how on-ledger state is interpreted. Also changes CI migration gating logic, which could allow some schema changes to skip required migrations if the diff heuristic is wrong.
> 
> **Overview**
> Adds a **per-token flow limiter role** to `stellar-interchain-token-service`: operator-managed `add_flow_limiter`/`remove_flow_limiter`/`transfer_flow_limiter`, new `is_flow_limiter` query, and new events/errors. Updates `set_flow_limit` to take an explicit `caller: Address` and allow either the operator or an approved flow limiter to set limits (with auth required).
> 
> Extends contract storage with a new persistent `FlowLimiter { token_id, flow_limiter }` status key, updates golden schema output, and adds comprehensive tests/golden event fixtures for flow-limiter behavior and the new `set_flow_limit` authorization.
> 
> Improves migration CI (`.github/scripts/check-migration.sh`) to **skip requiring migrations for purely additive** storage schema golden-file changes, and normalizes generated storage schema formatting (`collapse_struct_variants`) to avoid false “additive-only” diffs caused by `prettyplease` line-wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7c91eea006f8b88c17b25ba4bdc9709c065e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->