### PR TITLE
chore(its): reconstruct canonical wXRP state on Stellar after v2.0.0 …

### DIFF
--- a/contracts/stellar-interchain-token-service/src/contract.rs
+++ b/contracts/stellar-interchain-token-service/src/contract.rs
@@ -9,9 +9,9 @@ use stellar_axelar_std::token::StellarAssetClient;
 use stellar_axelar_std::types::Token;
 use stellar_axelar_std::xdr::ToXdr;
 use stellar_axelar_std::{
-    contract, contractimpl, ensure, interfaces, only_operator, only_owner, soroban_sdk, vec,
-    when_not_paused, Address, AxelarExecutable, Bytes, BytesN, Env, IntoVal, Operatable, Ownable,
-    Pausable, String, Symbol, Upgradable, Val,
+    contract, contractimpl, contracttype, ensure, interfaces, only_operator, only_owner,
+    soroban_sdk, vec, when_not_paused, Address, AxelarExecutable, Bytes, BytesN, Env, IntoVal,
+    Operatable, Ownable, Pausable, String, Symbol, Upgradable, Val,
 };
 use stellar_token_manager::TokenManagerClient;
 use token_id::UnregisteredTokenId;
@@ -39,6 +39,7 @@ const EXECUTE_WITH_INTERCHAIN_TOKEN: &str = "execute_with_interchain_token";
 
 #[contract]
 #[derive(Operatable, Ownable, Pausable, Upgradable, AxelarExecutable)]
+#[migratable]
 pub struct InterchainTokenService;
 
 #[contractimpl]
@@ -947,43 +948,52 @@ impl InterchainTokenService {
     }
 }
 
-/// Reconstruct the canonical wXRP state on Stellar.
+/// Reconstruct canonical interchain-token state for a token whose `TokenIdConfig`
+/// was wiped by a prior cleanup migration but whose deterministically-addressed
+/// TokenManager Soroban contract still occupies its slot.
 ///
-/// The previous migration (v2.0.0) removed the orphan `TokenIdConfig{ba5a21ca…}` left over
-/// from the third-party "ultratoken.xyz" P2P registration. That cleared the storage record
-/// but did not — and could not — remove the orphan TokenManager Soroban contract still
-/// occupying the deterministic address derived from this ITS + the XRP token-id salt.
-/// A fresh canonical deploy from XRPL collides at `deploy_v2` with `Storage, ExistingValue`.
-///
-/// Soroban has no `delete contract` primitive, but the orphan TokenManager's
+/// Context (wXRP, the original trigger): the v2.0.0 migration removed the orphan
+/// `TokenIdConfig{ba5a21ca…}` left over from a third-party P2P registration, but
+/// Soroban has no `delete contract` primitive — the TokenManager at the canonical
+/// deterministic address stays put, so a fresh canonical deploy hits
+/// `Storage, ExistingValue` at `deploy_v2`. The orphan TokenManager's
 /// `Interfaces_Owner` is this ITS itself, so we can upgrade its wasm in-place.
 ///
-/// This migration reconstructs the state as if a canonical XRPL → Stellar deploy had
-/// just succeeded:
-///   1. Upgrade the orphan TokenManager at the deterministic address to the canonical
-///      `stellar-token-manager` wasm + run its (no-op) migrate to clear the migrating flag.
+/// This migration reconstructs the state as if a canonical deploy had just
+/// succeeded for the supplied `token_id` / metadata:
+///   1. Upgrade the orphan TokenManager at the deterministic address to the
+///      canonical `stellar-token-manager` wasm + run its (no-op) migrate to clear
+///      the migrating flag.
 ///   2. Deploy the canonical InterchainToken at its deterministic address with the
-///      "Wrapped XRP" / "wXRP" / 6-decimals metadata, owned by this ITS.
-///   3. Persist `TokenIdConfig{ba5a21ca…} = { token_address: <new IT>,
-///      token_manager: <orphan addr>, type: NativeInterchainToken }` and run the
-///      post-deploy hook that adds the TokenManager as a minter on the InterchainToken.
-///   4. Consume the corresponding approved-but-unexecuted DeployInterchainToken GMP on
-///      the Stellar gateway via `validate_message`, so it doesn't sit as a permanently
-///      stuck approval.
+///      supplied metadata, owned by this ITS.
+///   3. Persist `TokenIdConfig{token_id} = { token_address, token_manager,
+///      type: NativeInterchainToken }` and run the post-deploy hook that adds the
+///      TokenManager as a minter on the InterchainToken.
+///
+/// Any `MessageApproved` GMP that was previously approved on the gateway for this
+/// same `token_id` (e.g. the original wXRP deploy on mainnet) is deliberately
+/// **left dangling**. After this migration `TokenIdConfig{token_id}` is populated,
+/// so any future `execute` attempt routes through ITS's `DeployInterchainToken`
+/// handling and reverts at `ensure_token_not_registered` — no replay risk, no
+/// state corruption, just a cosmetic "Approved, not executed" entry on axelarscan.
 impl CustomMigratableInterface for InterchainTokenService {
-    type MigrationData = ();
+    type MigrationData = RecoveryMigrationData;
     type Error = ContractError;
 
-    fn __migrate(env: &Env, _migration_data: ()) -> Result<(), Self::Error> {
-        let token_id = BytesN::from_array(env, &XRP_TOKEN_ID);
+    fn __migrate(env: &Env, migration_data: RecoveryMigrationData) -> Result<(), Self::Error> {
+        let RecoveryMigrationData {
+            token_decimals,
+            token_id,
+            token_name,
+            token_symbol,
+        } = migration_data;
 
         // 1. Repurpose the orphan TokenManager: swap its wasm to canonical and finalize the
         //    upgrade by running migrate (default no-op `__migrate` on stellar-token-manager,
         //    needed to clear the `interfaces_migrating` flag set by `upgrade`).
         let token_manager_address = deployer::token_manager_address(env, token_id.clone());
         let canonical_token_manager_wasm = storage::token_manager_wasm_hash(env);
-        let token_manager_upgradable_client =
-            UpgradableClient::new(env, &token_manager_address);
+        let token_manager_upgradable_client = UpgradableClient::new(env, &token_manager_address);
         token_manager_upgradable_client.upgrade(&canonical_token_manager_wasm);
         // `Upgradable` derive generates `migrate` as a contract entrypoint but it isn't
         // exposed on the auto-generated `TokenManagerClient` (the trait has generic
@@ -997,14 +1007,10 @@ impl CustomMigratableInterface for InterchainTokenService {
         );
 
         // 2. Deploy the canonical InterchainToken at its (currently empty) deterministic
-        //    address. `ensure_token_not_registered` succeeds because v2.0.0 already removed
-        //    the orphan TokenIdConfig entry.
+        //    address. `ensure_token_not_registered` succeeds because the prior cleanup
+        //    migration already removed the orphan TokenIdConfig entry.
         let unregistered_token_id = token_id::ensure_token_not_registered(env, token_id.clone())?;
-        let token_metadata = TokenMetadata::new(
-            String::from_str(env, "Wrapped XRP"),
-            String::from_str(env, "wXRP"),
-            6,
-        )?;
+        let token_metadata = TokenMetadata::new(token_name, token_symbol, token_decimals)?;
         let token_address = deployer::deploy_interchain_token(
             env,
             storage::interchain_token_wasm_hash(env),
@@ -1028,48 +1034,26 @@ impl CustomMigratableInterface for InterchainTokenService {
             token_address,
         );
 
-        // 4. Consume the pending DeployInterchainToken GMP that was already approved on
-        //    the Stellar gateway (from the canonical XRPL → Stellar deploy attempt that
-        //    triggered this whole recovery). Marking it Executed prevents anyone from
-        //    re-trying it forever — and the work it would have done is already done here.
-        //    The return value is ignored: if the message isn't present (e.g. on testnet
-        //    or a chain where the deploy wasn't attempted) we no-op silently.
-        let gateway = AxelarGatewayMessagingClient::new(env, &storage::gateway(env));
-        let _ = gateway.try_validate_message(
-            &env.current_contract_address(),
-            &String::from_str(env, "axelar"),
-            &String::from_str(env, PENDING_DEPLOY_MESSAGE_ID),
-            &String::from_str(env, ITS_HUB_AXELAR_ADDRESS),
-            &BytesN::from_array(env, &PENDING_DEPLOY_PAYLOAD_HASH),
-        );
-
         Ok(())
     }
 }
 
-/// Canonical XRP ITS token id (`0xba5a21ca…2824f`). Identical on testnet and mainnet —
-/// derived deterministically from the XRPL gateway's instantiation parameters.
-const XRP_TOKEN_ID: [u8; 32] = [
-    0xba, 0x5a, 0x21, 0xca, 0x88, 0xef, 0x6b, 0xba, 0x2b, 0xff, 0xf5, 0x08, 0x89, 0x94, 0xf9, 0x0e,
-    0x10, 0x77, 0xe2, 0xa1, 0xcc, 0x3d, 0xcc, 0x38, 0xbd, 0x26, 0x1f, 0x00, 0xfc, 0xe2, 0x82, 0x4f,
-];
-
-/// Source-chain message id of the in-flight DeployInterchainToken GMP that the canonical
-/// XRPL → Stellar deploy emitted from the ITS Hub. Approved on the Stellar mainnet
-/// gateway but unexecuted (the original `execute` reverted at the deterministic-address
-/// collision before this migration reconstructed state).
-const PENDING_DEPLOY_MESSAGE_ID: &str =
-    "0xaea4fb72e8a30dc031c0844ced529a928f35f7339d3a0c39096838d3d70bf61d-5903134";
-
-/// ITS Hub cosmwasm address — same on testnet and mainnet.
-const ITS_HUB_AXELAR_ADDRESS: &str =
-    "axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr";
-
-/// keccak256 of the pending DeployInterchainToken payload.
-const PENDING_DEPLOY_PAYLOAD_HASH: [u8; 32] = [
-    0x4d, 0xd1, 0x0f, 0x3b, 0x86, 0x4a, 0xb1, 0xeb, 0x0a, 0x2f, 0x4f, 0x7c, 0x5d, 0x56, 0x5f, 0xcc,
-    0x3a, 0x4d, 0x9f, 0x55, 0x30, 0x83, 0x5c, 0x0b, 0x02, 0xb0, 0xac, 0x96, 0xfe, 0x9e, 0x17, 0x12,
-];
+/// Input to the recovery `__migrate` above. Carries the token-specific values
+/// that would otherwise have to be hardcoded per-network, letting the same
+/// migration body run on devnet/testnet (with a fabricated repro token) and
+/// mainnet (with wXRP: token_id `0xba5a21ca…2824f`, "Wrapped XRP" / "wXRP" / 6).
+///
+/// Fields are kept alphabetically ordered because `#[contracttype]` serializes
+/// structs as ScVal maps with sorted keys — keeping the source order matched
+/// makes the encoding deterministic and easier to inspect.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RecoveryMigrationData {
+    pub token_decimals: u32,
+    pub token_id: BytesN<32>,
+    pub token_name: String,
+    pub token_symbol: String,
+}
 
 impl CustomAxelarExecutable for InterchainTokenService {
     type Error = ContractError;

--- a/contracts/stellar-interchain-token-service/src/contract.rs
+++ b/contracts/stellar-interchain-token-service/src/contract.rs
@@ -4,6 +4,7 @@ use stellar_axelar_gateway::executable::{AxelarExecutableInterface, CustomAxelar
 use stellar_axelar_gateway::AxelarGatewayMessagingClient;
 use stellar_axelar_std::address::AddressExt;
 use stellar_axelar_std::events::Event;
+use stellar_axelar_std::interfaces::{CustomMigratableInterface, UpgradableClient};
 use stellar_axelar_std::token::StellarAssetClient;
 use stellar_axelar_std::types::Token;
 use stellar_axelar_std::xdr::ToXdr;
@@ -945,6 +946,130 @@ impl InterchainTokenService {
         Ok(token_address)
     }
 }
+
+/// Reconstruct the canonical wXRP state on Stellar.
+///
+/// The previous migration (v2.0.0) removed the orphan `TokenIdConfig{ba5a21ca…}` left over
+/// from the third-party "ultratoken.xyz" P2P registration. That cleared the storage record
+/// but did not — and could not — remove the orphan TokenManager Soroban contract still
+/// occupying the deterministic address derived from this ITS + the XRP token-id salt.
+/// A fresh canonical deploy from XRPL collides at `deploy_v2` with `Storage, ExistingValue`.
+///
+/// Soroban has no `delete contract` primitive, but the orphan TokenManager's
+/// `Interfaces_Owner` is this ITS itself, so we can upgrade its wasm in-place.
+///
+/// This migration reconstructs the state as if a canonical XRPL → Stellar deploy had
+/// just succeeded:
+///   1. Upgrade the orphan TokenManager at the deterministic address to the canonical
+///      `stellar-token-manager` wasm + run its (no-op) migrate to clear the migrating flag.
+///   2. Deploy the canonical InterchainToken at its deterministic address with the
+///      "Wrapped XRP" / "wXRP" / 6-decimals metadata, owned by this ITS.
+///   3. Persist `TokenIdConfig{ba5a21ca…} = { token_address: <new IT>,
+///      token_manager: <orphan addr>, type: NativeInterchainToken }` and run the
+///      post-deploy hook that adds the TokenManager as a minter on the InterchainToken.
+///   4. Consume the corresponding approved-but-unexecuted DeployInterchainToken GMP on
+///      the Stellar gateway via `validate_message`, so it doesn't sit as a permanently
+///      stuck approval.
+impl CustomMigratableInterface for InterchainTokenService {
+    type MigrationData = ();
+    type Error = ContractError;
+
+    fn __migrate(env: &Env, _migration_data: ()) -> Result<(), Self::Error> {
+        let token_id = BytesN::from_array(env, &XRP_TOKEN_ID);
+
+        // 1. Repurpose the orphan TokenManager: swap its wasm to canonical and finalize the
+        //    upgrade by running migrate (default no-op `__migrate` on stellar-token-manager,
+        //    needed to clear the `interfaces_migrating` flag set by `upgrade`).
+        let token_manager_address = deployer::token_manager_address(env, token_id.clone());
+        let canonical_token_manager_wasm = storage::token_manager_wasm_hash(env);
+        let token_manager_upgradable_client =
+            UpgradableClient::new(env, &token_manager_address);
+        token_manager_upgradable_client.upgrade(&canonical_token_manager_wasm);
+        // `Upgradable` derive generates `migrate` as a contract entrypoint but it isn't
+        // exposed on the auto-generated `TokenManagerClient` (the trait has generic
+        // associated types, so the contractclient skips it). Invoke it by name to clear
+        // the `interfaces_migrating` flag set by `upgrade`. The canonical TokenManager's
+        // `MigrationData` is `()` and its `__migrate` is the default no-op.
+        let _: Val = env.invoke_contract(
+            &token_manager_address,
+            &Symbol::new(env, "migrate"),
+            vec![env, ().into_val(env)],
+        );
+
+        // 2. Deploy the canonical InterchainToken at its (currently empty) deterministic
+        //    address. `ensure_token_not_registered` succeeds because v2.0.0 already removed
+        //    the orphan TokenIdConfig entry.
+        let unregistered_token_id = token_id::ensure_token_not_registered(env, token_id.clone())?;
+        let token_metadata = TokenMetadata::new(
+            String::from_str(env, "Wrapped XRP"),
+            String::from_str(env, "wXRP"),
+            6,
+        )?;
+        let token_address = deployer::deploy_interchain_token(
+            env,
+            storage::interchain_token_wasm_hash(env),
+            None,
+            unregistered_token_id,
+            token_metadata,
+        );
+
+        // 3. Persist the TokenIdConfig record and grant the TokenManager mint authority on
+        //    the freshly-deployed InterchainToken (canonical NativeInterchainToken setup).
+        let token_id_config = TokenIdConfigValue {
+            token_address: token_address.clone(),
+            token_manager: token_manager_address.clone(),
+            token_manager_type: TokenManagerType::NativeInterchainToken,
+        };
+        storage::set_token_id_config(env, token_id, &token_id_config);
+        token_handler::post_token_manager_deploy(
+            env,
+            TokenManagerType::NativeInterchainToken,
+            token_manager_address,
+            token_address,
+        );
+
+        // 4. Consume the pending DeployInterchainToken GMP that was already approved on
+        //    the Stellar gateway (from the canonical XRPL → Stellar deploy attempt that
+        //    triggered this whole recovery). Marking it Executed prevents anyone from
+        //    re-trying it forever — and the work it would have done is already done here.
+        //    The return value is ignored: if the message isn't present (e.g. on testnet
+        //    or a chain where the deploy wasn't attempted) we no-op silently.
+        let gateway = AxelarGatewayMessagingClient::new(env, &storage::gateway(env));
+        let _ = gateway.try_validate_message(
+            &env.current_contract_address(),
+            &String::from_str(env, "axelar"),
+            &String::from_str(env, PENDING_DEPLOY_MESSAGE_ID),
+            &String::from_str(env, ITS_HUB_AXELAR_ADDRESS),
+            &BytesN::from_array(env, &PENDING_DEPLOY_PAYLOAD_HASH),
+        );
+
+        Ok(())
+    }
+}
+
+/// Canonical XRP ITS token id (`0xba5a21ca…2824f`). Identical on testnet and mainnet —
+/// derived deterministically from the XRPL gateway's instantiation parameters.
+const XRP_TOKEN_ID: [u8; 32] = [
+    0xba, 0x5a, 0x21, 0xca, 0x88, 0xef, 0x6b, 0xba, 0x2b, 0xff, 0xf5, 0x08, 0x89, 0x94, 0xf9, 0x0e,
+    0x10, 0x77, 0xe2, 0xa1, 0xcc, 0x3d, 0xcc, 0x38, 0xbd, 0x26, 0x1f, 0x00, 0xfc, 0xe2, 0x82, 0x4f,
+];
+
+/// Source-chain message id of the in-flight DeployInterchainToken GMP that the canonical
+/// XRPL → Stellar deploy emitted from the ITS Hub. Approved on the Stellar mainnet
+/// gateway but unexecuted (the original `execute` reverted at the deterministic-address
+/// collision before this migration reconstructed state).
+const PENDING_DEPLOY_MESSAGE_ID: &str =
+    "0xaea4fb72e8a30dc031c0844ced529a928f35f7339d3a0c39096838d3d70bf61d-5903134";
+
+/// ITS Hub cosmwasm address — same on testnet and mainnet.
+const ITS_HUB_AXELAR_ADDRESS: &str =
+    "axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr";
+
+/// keccak256 of the pending DeployInterchainToken payload.
+const PENDING_DEPLOY_PAYLOAD_HASH: [u8; 32] = [
+    0x4d, 0xd1, 0x0f, 0x3b, 0x86, 0x4a, 0xb1, 0xeb, 0x0a, 0x2f, 0x4f, 0x7c, 0x5d, 0x56, 0x5f, 0xcc,
+    0x3a, 0x4d, 0x9f, 0x55, 0x30, 0x83, 0x5c, 0x0b, 0x02, 0xb0, 0xac, 0x96, 0xfe, 0x9e, 0x17, 0x12,
+];
 
 impl CustomAxelarExecutable for InterchainTokenService {
     type Error = ContractError;

--- a/contracts/stellar-interchain-token-service/src/lib.rs
+++ b/contracts/stellar-interchain-token-service/src/lib.rs
@@ -29,7 +29,9 @@ cfg_if::cfg_if! {
         mod contract;
         mod flow_limit;
 
-        pub use contract::{InterchainTokenService, InterchainTokenServiceClient};
+        pub use contract::{
+            InterchainTokenService, InterchainTokenServiceClient, RecoveryMigrationData,
+        };
         pub use interface::InterchainTokenServiceInterface;
     }
 }

--- a/contracts/stellar-interchain-token-service/src/tests/migration.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/migration.rs
@@ -1,25 +1,63 @@
 use stellar_axelar_std::interfaces::CustomMigratableInterface;
 use stellar_axelar_std::xdr::ToXdr;
-use stellar_axelar_std::{Address, BytesN, String};
+use stellar_axelar_std::{Address, BytesN, Env, String};
 
 use super::utils::setup_env;
 use crate::storage;
 use crate::types::TokenManagerType;
-use crate::{deployer, InterchainTokenService};
+use crate::{deployer, InterchainTokenService, RecoveryMigrationData};
 
+/// Canonical XRP ITS token id (`0xba5a21ca…2824f`) — the mainnet wXRP repro case.
 const XRP_TOKEN_ID: [u8; 32] = [
     0xba, 0x5a, 0x21, 0xca, 0x88, 0xef, 0x6b, 0xba, 0x2b, 0xff, 0xf5, 0x08, 0x89, 0x94, 0xf9, 0x0e,
     0x10, 0x77, 0xe2, 0xa1, 0xcc, 0x3d, 0xcc, 0x38, 0xbd, 0x26, 0x1f, 0x00, 0xfc, 0xe2, 0x82, 0x4f,
 ];
 
+/// An arbitrary other token id, used to prove the migration body is genuinely
+/// parameterized and not implicitly coupled to the wXRP constants. Any non-wXRP
+/// value works — choosing one that's distinct in every byte makes failures obvious.
+const REPRO_TOKEN_ID: [u8; 32] = [
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+];
+
+/// Pre-deploy a canonical TokenManager at the deterministic address for `token_id`,
+/// simulating the orphan left over from a P2P registration on a real network.
+/// Returns the deterministic TokenManager address the migration will resolve to.
+fn pre_deploy_orphan_token_manager(
+    env: &Env,
+    its_address: &Address,
+    token_id: &BytesN<32>,
+) -> Address {
+    env.as_contract(its_address, || -> Address {
+        let token_manager_wasm = storage::token_manager_wasm_hash(env);
+        // Mirror the deployer's salt derivation so the deterministic address matches
+        // what the migration's `deployer::token_manager_address` will resolve to.
+        let salt: BytesN<32> = env
+            .crypto()
+            .keccak256(
+                &(
+                    String::from_str(env, "its-token-manager-salt"),
+                    token_id.clone(),
+                )
+                    .to_xdr(env),
+            )
+            .into();
+        env.deployer()
+            .with_current_contract(salt)
+            .deploy_v2(token_manager_wasm, (env.current_contract_address(),))
+    })
+}
+
+/// Mainnet repro: wXRP token_id + canonical Wrapped XRP / wXRP / 6 metadata.
+///
 /// The migration assumes an orphan TokenManager contract exists at the canonical
 /// deterministic address (deployed by this ITS during a prior P2P registration).
-/// To exercise that path in a unit test, we pre-deploy a TokenManager at the same
-/// deterministic address using the canonical wasm — that lets the migration's
-/// `UpgradableClient::upgrade` and follow-up `migrate` calls succeed against a
-/// well-formed target. The migration then deploys the InterchainToken, sets the
-/// TokenIdConfig, and runs `post_token_manager_deploy` (which adds the TokenManager
-/// as a minter on the InterchainToken).
+/// We pre-deploy a TokenManager at the same deterministic address using the
+/// canonical wasm — that lets the migration's `UpgradableClient::upgrade` and
+/// follow-up `migrate` calls succeed against a well-formed target. The migration
+/// then deploys the InterchainToken, sets the TokenIdConfig, and runs
+/// `post_token_manager_deploy` (which adds the TokenManager as a minter on the IT).
 #[test]
 fn migration_reconstructs_wxrp_state() {
     let (env, client, _gateway_client, _, _) = setup_env();
@@ -31,31 +69,22 @@ fn migration_reconstructs_wxrp_state() {
         assert!(storage::try_token_id_config(&env, xrp_token_id.clone()).is_none());
     });
 
-    // Pre-deploy a canonical TokenManager at the deterministic XRP address, simulating
-    // the orphan left over from a P2P registration on a real network.
-    let expected_token_manager = env.as_contract(&client.address, || -> Address {
-        let token_manager_wasm = storage::token_manager_wasm_hash(&env);
-        // Mirror the deployer's salt derivation so the deterministic address matches what
-        // the migration's `deployer::token_manager_address` will resolve to.
-        let salt: BytesN<32> = env
-            .crypto()
-            .keccak256(
-                &(
-                    String::from_str(&env, "its-token-manager-salt"),
-                    xrp_token_id.clone(),
-                )
-                    .to_xdr(&env),
-            )
-            .into();
-        env.deployer()
-            .with_current_contract(salt)
-            .deploy_v2(token_manager_wasm, (env.current_contract_address(),))
-    });
+    let expected_token_manager =
+        pre_deploy_orphan_token_manager(&env, &client.address, &xrp_token_id);
 
-    // Run the migration.
+    // Run the migration with the mainnet wXRP params.
     client.mock_all_auths();
     env.as_contract(&client.address, || {
-        InterchainTokenService::__migrate(&env, ()).unwrap();
+        InterchainTokenService::__migrate(
+            &env,
+            RecoveryMigrationData {
+                token_decimals: 6,
+                token_id: xrp_token_id.clone(),
+                token_name: String::from_str(&env, "Wrapped XRP"),
+                token_symbol: String::from_str(&env, "wXRP"),
+            },
+        )
+        .unwrap();
     });
 
     // Post-condition: TokenIdConfig populated, pointing at the (now upgraded-in-place)
@@ -63,11 +92,60 @@ fn migration_reconstructs_wxrp_state() {
     env.as_contract(&client.address, || {
         let cfg = storage::try_token_id_config(&env, xrp_token_id.clone()).unwrap();
         assert_eq!(cfg.token_manager, expected_token_manager);
-        assert_eq!(cfg.token_manager_type, TokenManagerType::NativeInterchainToken);
+        assert_eq!(
+            cfg.token_manager_type,
+            TokenManagerType::NativeInterchainToken
+        );
         // InterchainToken was newly deployed at the canonical deterministic address.
         assert_eq!(
             cfg.token_address,
             deployer::interchain_token_address(&env, xrp_token_id)
+        );
+    });
+}
+
+/// Devnet/testnet repro: same migration body, different token_id + metadata.
+/// Exists to prove the migration is genuinely parameterized — i.e. the wXRP case
+/// isn't implicitly coupled to constants somewhere — and to give devnet/testnet
+/// validation a non-wXRP path it can reproduce without needing the real XRPL
+/// gateway's instantiation parameters.
+#[test]
+fn migration_reconstructs_arbitrary_token_state() {
+    let (env, client, _gateway_client, _, _) = setup_env();
+
+    let repro_token_id = BytesN::<32>::from_array(&env, &REPRO_TOKEN_ID);
+
+    env.as_contract(&client.address, || {
+        assert!(storage::try_token_id_config(&env, repro_token_id.clone()).is_none());
+    });
+
+    let expected_token_manager =
+        pre_deploy_orphan_token_manager(&env, &client.address, &repro_token_id);
+
+    client.mock_all_auths();
+    env.as_contract(&client.address, || {
+        InterchainTokenService::__migrate(
+            &env,
+            RecoveryMigrationData {
+                token_decimals: 18,
+                token_id: repro_token_id.clone(),
+                token_name: String::from_str(&env, "Devnet Repro Token"),
+                token_symbol: String::from_str(&env, "REPRO"),
+            },
+        )
+        .unwrap();
+    });
+
+    env.as_contract(&client.address, || {
+        let cfg = storage::try_token_id_config(&env, repro_token_id.clone()).unwrap();
+        assert_eq!(cfg.token_manager, expected_token_manager);
+        assert_eq!(
+            cfg.token_manager_type,
+            TokenManagerType::NativeInterchainToken
+        );
+        assert_eq!(
+            cfg.token_address,
+            deployer::interchain_token_address(&env, repro_token_id)
         );
     });
 }

--- a/contracts/stellar-interchain-token-service/src/tests/migration.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/migration.rs
@@ -1,0 +1,73 @@
+use stellar_axelar_std::interfaces::CustomMigratableInterface;
+use stellar_axelar_std::xdr::ToXdr;
+use stellar_axelar_std::{Address, BytesN, String};
+
+use super::utils::setup_env;
+use crate::storage;
+use crate::types::TokenManagerType;
+use crate::{deployer, InterchainTokenService};
+
+const XRP_TOKEN_ID: [u8; 32] = [
+    0xba, 0x5a, 0x21, 0xca, 0x88, 0xef, 0x6b, 0xba, 0x2b, 0xff, 0xf5, 0x08, 0x89, 0x94, 0xf9, 0x0e,
+    0x10, 0x77, 0xe2, 0xa1, 0xcc, 0x3d, 0xcc, 0x38, 0xbd, 0x26, 0x1f, 0x00, 0xfc, 0xe2, 0x82, 0x4f,
+];
+
+/// The migration assumes an orphan TokenManager contract exists at the canonical
+/// deterministic address (deployed by this ITS during a prior P2P registration).
+/// To exercise that path in a unit test, we pre-deploy a TokenManager at the same
+/// deterministic address using the canonical wasm — that lets the migration's
+/// `UpgradableClient::upgrade` and follow-up `migrate` calls succeed against a
+/// well-formed target. The migration then deploys the InterchainToken, sets the
+/// TokenIdConfig, and runs `post_token_manager_deploy` (which adds the TokenManager
+/// as a minter on the InterchainToken).
+#[test]
+fn migration_reconstructs_wxrp_state() {
+    let (env, client, _gateway_client, _, _) = setup_env();
+
+    let xrp_token_id = BytesN::<32>::from_array(&env, &XRP_TOKEN_ID);
+
+    // Pre-condition: no TokenIdConfig.
+    env.as_contract(&client.address, || {
+        assert!(storage::try_token_id_config(&env, xrp_token_id.clone()).is_none());
+    });
+
+    // Pre-deploy a canonical TokenManager at the deterministic XRP address, simulating
+    // the orphan left over from a P2P registration on a real network.
+    let expected_token_manager = env.as_contract(&client.address, || -> Address {
+        let token_manager_wasm = storage::token_manager_wasm_hash(&env);
+        // Mirror the deployer's salt derivation so the deterministic address matches what
+        // the migration's `deployer::token_manager_address` will resolve to.
+        let salt: BytesN<32> = env
+            .crypto()
+            .keccak256(
+                &(
+                    String::from_str(&env, "its-token-manager-salt"),
+                    xrp_token_id.clone(),
+                )
+                    .to_xdr(&env),
+            )
+            .into();
+        env.deployer()
+            .with_current_contract(salt)
+            .deploy_v2(token_manager_wasm, (env.current_contract_address(),))
+    });
+
+    // Run the migration.
+    client.mock_all_auths();
+    env.as_contract(&client.address, || {
+        InterchainTokenService::__migrate(&env, ()).unwrap();
+    });
+
+    // Post-condition: TokenIdConfig populated, pointing at the (now upgraded-in-place)
+    // TokenManager and a freshly-deployed InterchainToken; type is NativeInterchainToken.
+    env.as_contract(&client.address, || {
+        let cfg = storage::try_token_id_config(&env, xrp_token_id.clone()).unwrap();
+        assert_eq!(cfg.token_manager, expected_token_manager);
+        assert_eq!(cfg.token_manager_type, TokenManagerType::NativeInterchainToken);
+        // InterchainToken was newly deployed at the canonical deterministic address.
+        assert_eq!(
+            cfg.token_address,
+            deployer::interchain_token_address(&env, xrp_token_id)
+        );
+    });
+}

--- a/contracts/stellar-interchain-token-service/src/tests/migration.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/migration.rs
@@ -3,9 +3,8 @@ use stellar_axelar_std::xdr::ToXdr;
 use stellar_axelar_std::{Address, BytesN, Env, String};
 
 use super::utils::setup_env;
-use crate::storage;
 use crate::types::TokenManagerType;
-use crate::{deployer, InterchainTokenService, RecoveryMigrationData};
+use crate::{deployer, storage, InterchainTokenService, RecoveryMigrationData};
 
 /// Canonical XRP ITS token id (`0xba5a21ca…2824f`) — the mainnet wXRP repro case.
 const XRP_TOKEN_ID: [u8; 32] = [

--- a/contracts/stellar-interchain-token-service/src/tests/mod.rs
+++ b/contracts/stellar-interchain-token-service/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod flow_limiter;
 mod interchain_transfer;
 mod link_token;
 mod message_routing;
+mod migration;
 mod pause;
 mod register_canonical_token;
 mod register_custom_token;


### PR DESCRIPTION
…cleanup

The v2.0.0 migration removed the orphan TokenIdConfig{ba5a21ca…} left over from the ultratoken.xyz P2P registration, but the deployed TokenManager Soroban contract at the deterministic address still occupies the slot — Soroban has no contract-delete primitive. A fresh canonical XRPL → Stellar deploy hits Storage, ExistingValue at deploy_v2.

The orphan TokenManager's Interfaces_Owner is this ITS contract, so we can upgrade its wasm in-place. This migration:

  1. Upgrades the orphan TokenManager at the canonical deterministic address to the canonical stellar-token-manager wasm + clears the migrating flag.
  2. Deploys the canonical InterchainToken with 'Wrapped XRP' / 'wXRP' / 6 metadata at its (still-empty) deterministic address.
  3. Persists TokenIdConfig{ba5a21ca…} pointing at both, and runs the post-deploy hook that adds the TokenManager as a minter on the new InterchainToken (canonical NativeInterchainToken setup).
  4. Consumes the in-flight DeployInterchainToken GMP that was approved on the Stellar mainnet gateway but reverted at execute (the original trigger for this whole recovery), so it doesn't sit as a stuck approval.

End state matches what a clean canonical deploy from XRPL would have produced on a chain that never had the P2P orphan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> On-chain migration mutates live token manager wasm, deploys tokens, and sets ITS registration state on mainnet; mistakes could brick wXRP or mis-wire mint authority.
> 
> **Overview**
> Adds a **parameterized recovery migration** on Stellar ITS (`#[migratable]` + `CustomMigratableInterface`) to fix the post–v2.0.0 wXRP situation: orphan `TokenIdConfig` was removed but the deterministic **TokenManager** contract still blocks a fresh canonical deploy.
> 
> `__migrate` takes `RecoveryMigrationData` (`token_id`, name, symbol, decimals), **upgrades** the orphan TokenManager at the canonical address to canonical wasm and invokes **`migrate`** to clear the upgrading flag, **deploys** the InterchainToken at its deterministic slot, then writes **`TokenIdConfig`** as `NativeInterchainToken` and runs **`post_token_manager_deploy`** (minter wiring). Previously approved deploy GMPs for that `token_id` are **not** executed; later `execute` would fail at `ensure_token_not_registered`.
> 
> Exports `RecoveryMigrationData` from the crate and adds tests that simulate an orphan TokenManager for mainnet wXRP and an arbitrary token id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8044897ed86052f3792da5246cf97ae7e330c6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->