### PR TITLE
ci: build contracts with source-repo for verification

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -40,6 +40,10 @@ jobs:
   build:
     needs: stellar-contract-names
     uses: ./.github/workflows/reusable-build.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     with:
       commit-hash: ${{ needs.stellar-contract-names.outputs.commit_hash }}
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -46,6 +46,7 @@ jobs:
       attestations: write
     with:
       commit-hash: ${{ needs.stellar-contract-names.outputs.commit_hash }}
+      attest: false
 
   upload:
     needs: [stellar-contract-names, build]

--- a/.github/workflows/release-upload-to-r2.yaml
+++ b/.github/workflows/release-upload-to-r2.yaml
@@ -88,6 +88,7 @@ jobs:
       attestations: write
     with:
       commit-hash: ${{ needs.prepare-release.outputs.commit_hash }}
+      attest: false
 
   upload:
     needs: [prepare-release, build]

--- a/.github/workflows/release-upload-to-r2.yaml
+++ b/.github/workflows/release-upload-to-r2.yaml
@@ -82,6 +82,10 @@ jobs:
   build:
     needs: prepare-release
     uses: ./.github/workflows/reusable-build.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     with:
       commit-hash: ${{ needs.prepare-release.outputs.commit_hash }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,7 @@ jobs:
       attestations: write
     with:
       commit-hash: ${{ needs.publish-release.outputs.commit_hash }}
+      attest: true
 
   upload:
     needs: [publish-release, build]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,10 @@ jobs:
   build:
     needs: publish-release
     uses: ./.github/workflows/reusable-build.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     with:
       commit-hash: ${{ needs.publish-release.outputs.commit_hash }}
 

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -7,6 +7,11 @@ on:
         description: "The commit hash to build from"
         type: string
         required: true
+      attest:
+        description: "Whether to create GitHub build provenance attestations for the WASM artifacts"
+        type: boolean
+        default: false
+        required: false
     outputs:
       artifact-name:
         description: "Name of the uploaded artifact containing all builds"
@@ -31,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify build ref matches workflow ref
+        if: inputs.attest
         run: |
           build_commit=$(git rev-parse "${{ inputs.commit-hash }}")
           workflow_commit=$(git rev-parse "${{ github.sha }}")
@@ -72,6 +78,7 @@ jobs:
           find . -maxdepth 1 -type f ! -name "*.wasm" -delete
 
       - name: Attest WASM artifacts
+        if: inputs.attest
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/wasm32v1-none/release/*.wasm

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -18,6 +18,10 @@ on:
 jobs:
   build:
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.name }}
       artifact-path: ${{ steps.set-artifact-name.outputs.path }}
@@ -26,8 +30,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Verify build ref matches workflow ref
+        run: |
+          build_commit=$(git rev-parse "${{ inputs.commit-hash }}")
+          workflow_commit=$(git rev-parse "${{ github.sha }}")
+
+          if [ "$build_commit" != "$workflow_commit" ]; then
+            echo "Build commit $build_commit does not match workflow commit $workflow_commit."
+            echo "Run this workflow from the same ref that is being built so provenance matches the WASM source."
+            exit 1
+          fi
+
       - name: Checkout specific commit
-        run: git checkout ${{ inputs.commit-hash }}
+        run: git checkout "$(git rev-parse "${{ inputs.commit-hash }}")"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -48,13 +63,18 @@ jobs:
       - name: Build all contracts
         run: |
           # Build and optimize all contracts
-          stellar contract build --optimize
+          stellar contract build --optimize --meta source_repo=github:${{ github.repository }}
 
           # Process in the release directory
           cd target/wasm32v1-none/release
 
           # Remove non-wasm files
           find . -maxdepth 1 -type f ! -name "*.wasm" -delete
+
+      - name: Attest WASM artifacts
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: target/wasm32v1-none/release/*.wasm
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes CPI-375


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release and pre-release build pipelines and artifact trust signals; attestation is gated to the main release workflow with a commit/ref guard.
> 
> **Overview**
> Contract WASM builds now embed **`source_repo=github:<repo>`** metadata via `stellar contract build --optimize --meta`, so artifacts can be tied back to this repository for verification (CPI-375).
> 
> The reusable **Build Contracts** workflow gains an **`attest`** input. When **`attest: true`** (used by **`release.yaml`**), the job checks that the requested build commit matches **`github.sha`**, then publishes GitHub **build provenance** attestations for `*.wasm` with `actions/attest-build-provenance@v4`. **Pre-release** and **manual R2 upload** workflows pass **`attest: false`** but still grant the OIDC/attestation permissions needed by the reusable workflow. Checkout now resolves the commit with **`git rev-parse`** before building.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e91abab650890db3b7d88594c7ff2b324868dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->