### PR TITLE
chore: bump rust toolchain to 1.93

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
 
       - name: Install libclang-dev
         run: sudo apt-get install libclang-dev

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
           targets: wasm32v1-none
           components: rust-src
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
           components: clippy
 
       - name: Rust Cache

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
 
       - name: Get commit hash
         id: get-commit-hash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
 
       - name: Get commit hash
         id: get-commit-hash

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
           targets: wasm32v1-none
           components: rust-src
 
@@ -43,7 +43,7 @@ jobs:
           echo "path=target/wasm32v1-none/release" >> $GITHUB_OUTPUT
 
       - name: Install Stellar CLI
-        uses: stellar/stellar-cli@v25.2.0
+        uses: stellar/stellar-cli@v26.1.0
 
       - name: Build all contracts
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
 
       - name: Rust Cache
         uses: useblacksmith/rust-cache@v3.0.1

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.93.0
 
       - name: Rust Cache
         uses: useblacksmith/rust-cache@v3.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760124fb65a2acdea7d241b8efdfab9a39287ae8dc5bf8feb6fd9dfb664c1ad5"
+checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
 dependencies = [
  "serde",
  "serde_json",
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb27e93f8d3fc3a815d24c60ec11e893c408a36693ec9c823322f954fa096ae"
+checksum = "4502f2e018f238a4c5d3212d7d20ea6abcdc6e58babd63b642b693739db30fd1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec603a62a90abdef898f8402471a24d8b58a0043b9a998ed6a607a19a5dabe1"
+checksum = "ca03e9cf61d241cb9afdd6ddf41f6c25698b3f566a875e7009ea799b89e2bf0a"
 dependencies = [
  "darling",
  "heck",
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24718fac3af127fc6910eb6b1d3ccd8403201b6ef0aca73b5acabe4bc3dd42ed"
+checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
 dependencies = [
  "base64",
  "sha2",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c558bca7a693ec8ed67d2d8c8f5b300f3772141d619a4a694ad5dd48461256"
+checksum = "6835bb510763ef3fa5405e89036e3c8ea6ef5abe55fc52cfe9ac0e38be9d531c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "25.3.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7257d888e42da01d031cfc388d4c9c10e4e13388a4e04deabf812fa7d33f0af3"
+checksum = "d8230fe7cf1bf138068cbe5cfa54a76657bed8a9bb6a89a4a229383116d3f067"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/*", "contracts/stellar-upgrader/src/tests/testdata/*", "pa
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.89.0"
+rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
@@ -17,7 +17,7 @@ paste = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
-soroban-token-sdk = { version = "25.3.0" }
+soroban-token-sdk = { version = "25.3.1" }
 stellar-axelar-example = { version = "^1.0.9", path = "contracts/stellar-axelar-example" }
 stellar-axelar-gas-service = { version = "^2.0.1", path = "contracts/stellar-axelar-gas-service" }
 stellar-axelar-gateway = { version = "^2.0.1", path = "contracts/stellar-axelar-gateway" }

--- a/packages/stellar-axelar-std/Cargo.toml
+++ b/packages/stellar-axelar-std/Cargo.toml
@@ -13,14 +13,14 @@ crate-type = ["rlib"]
 goldie = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-soroban-sdk = { version = "25.3.0" }
+soroban-sdk = { version = "25.3.1" }
 stellar-axelar-std-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 goldie = { workspace = true }
 hex = { workspace = true }
 paste = { workspace = true }
-soroban-sdk = { version = "25.3.0", features = ["testutils"] }
+soroban-sdk = { version = "25.3.1", features = ["testutils"] }
 stellar-axelar-std-derive = { workspace = true }
 
 [features]

--- a/packages/stellar-axelar-std/src/interfaces/testdata/contract_trivial_migration.rs
+++ b/packages/stellar-axelar-std/src/interfaces/testdata/contract_trivial_migration.rs
@@ -1,6 +1,5 @@
 use core::convert::Infallible;
 
-use stellar_axelar_std::testutils::arbitrary::std;
 use stellar_axelar_std::{
     contract, contracterror, contracttype, vec, Address, BytesN, Env, String, Vec,
 };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.93.0"
 targets = ["wasm32v1-none"]
 components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
bump rust to 1.93.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WASM release tooling and the Soroban SDK stack used by all contracts; behavior should be unchanged but compile output and CI need to pass on the new Rust and CLI versions.
> 
> **Overview**
> Aligns the repo and CI with **Rust 1.93.0** by updating `rust-toolchain.toml`, workspace `rust-version`, and every workflow that installs the stable toolchain (test, lint, compile, codecov, docs, release, and reusable WASM build).
> 
> **Soroban** dependencies move from **25.3.0 → 25.3.1** in `Cargo.toml`, `packages/stellar-axelar-std/Cargo.toml`, and `Cargo.lock` (including `soroban-sdk`, `soroban-token-sdk`, and related crates). Release builds use **stellar/stellar-cli@v26.1.0** (was v25.2.0).
> 
> Drops an unused `stellar_axelar_std::testutils::arbitrary::std` import in migration testdata so it compiles cleanly on the new toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27144806c81b0f2c6428073de0df5d98be723356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->