### PR TITLE
fix(axelar-std-derive): avoid internal aliases in contract specs

### DIFF
--- a/contracts/stellar-axelar-example/src/contract.rs
+++ b/contracts/stellar-axelar-example/src/contract.rs
@@ -16,6 +16,7 @@ use crate::storage;
 
 #[contract]
 #[derive(InterchainTokenExecutable, AxelarExecutable)]
+#[axelar_executable(error = AxelarExampleError)]
 pub struct AxelarExample;
 
 #[contracterror]

--- a/contracts/stellar-interchain-token-service/src/contract.rs
+++ b/contracts/stellar-interchain-token-service/src/contract.rs
@@ -38,6 +38,7 @@ const EXECUTE_WITH_INTERCHAIN_TOKEN: &str = "execute_with_interchain_token";
 
 #[contract]
 #[derive(Operatable, Ownable, Pausable, Upgradable, AxelarExecutable)]
+#[axelar_executable(error = ContractError)]
 pub struct InterchainTokenService;
 
 #[contractimpl]

--- a/packages/stellar-axelar-std-derive/src/axelar_executable.rs
+++ b/packages/stellar-axelar-std-derive/src/axelar_executable.rs
@@ -108,4 +108,35 @@ mod tests {
             "AxelarExecutable requires #[axelar_executable(error = ContractError)]"
         );
     }
+
+    #[test]
+    fn axelar_executable_impl_generation_rejects_unsupported_attribute() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(AxelarExecutable)]
+            #[axelar_executable(unsupported = Foo)]
+            pub struct Contract;
+        };
+
+        let err = crate::axelar_executable::axelar_executable(&contract_input).unwrap_err();
+
+        assert_eq!(err.to_string(), "unsupported axelar_executable attribute");
+    }
+
+    #[test]
+    fn axelar_executable_impl_generation_rejects_duplicate_error_type() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(AxelarExecutable)]
+            #[axelar_executable(error = ContractError, error = OtherError)]
+            pub struct Contract;
+        };
+
+        let err = crate::axelar_executable::axelar_executable(&contract_input).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "axelar_executable error type can only be specified once"
+        );
+    }
 }

--- a/packages/stellar-axelar-std-derive/src/axelar_executable.rs
+++ b/packages/stellar-axelar-std-derive/src/axelar_executable.rs
@@ -1,19 +1,15 @@
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::{DeriveInput, Error, Type};
 
-pub fn axelar_executable(name: &Ident) -> TokenStream2 {
-    let error_alias = Ident::new(
-        &format!("__{}AxelarExecutableInterfaceError", name),
-        name.span(),
-    );
+pub fn axelar_executable(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let error_type = error_type(input)?;
 
-    quote! {
+    Ok(quote! {
         use stellar_axelar_gateway::executable::AxelarExecutableInterface as _;
 
         impl stellar_axelar_gateway::executable::DeriveOnly for #name {}
-
-        #[allow(non_camel_case_types)]
-        type #error_alias = <#name as stellar_axelar_gateway::executable::CustomAxelarExecutable>::Error;
 
         #[stellar_axelar_std::contractimpl]
         impl AxelarExecutableInterface for #name {
@@ -28,13 +24,88 @@ pub fn axelar_executable(name: &Ident) -> TokenStream2 {
                 message_id: String,
                 source_address: String,
                 payload: Bytes,
-            ) -> Result<(), #error_alias> {
+            ) -> Result<(), #error_type> {
                 stellar_axelar_gateway::executable::validate_message::<Self>(env, &source_chain, &message_id, &source_address, &payload).map_err(|err| match err {
-                    stellar_axelar_gateway::executable::ValidationError::NotApproved => #error_alias::NotApproved,
+                    stellar_axelar_gateway::executable::ValidationError::NotApproved => #error_type::NotApproved,
                 })?;
 
                 Self::__execute(env, source_chain, message_id, source_address, payload)
             }
         }
+    })
+}
+
+fn error_type(input: &DeriveInput) -> syn::Result<Type> {
+    let mut error_type = None;
+
+    for attr in input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("axelar_executable"))
+    {
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("error") {
+                return Err(meta.error("unsupported axelar_executable attribute"));
+            }
+
+            if error_type.is_some() {
+                return Err(Error::new_spanned(
+                    &meta.path,
+                    "axelar_executable error type can only be specified once",
+                ));
+            }
+
+            let value = meta.value()?;
+            error_type = Some(value.parse()?);
+            Ok(())
+        })?;
+    }
+
+    error_type.ok_or_else(|| {
+        Error::new_spanned(
+            input,
+            "AxelarExecutable requires #[axelar_executable(error = ContractError)]",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    fn formatted_axelar_executable_impl(contract_input: syn::DeriveInput) -> String {
+        let axelar_executable_impl: proc_macro2::TokenStream =
+            crate::axelar_executable::axelar_executable(&contract_input).unwrap();
+        let axelar_executable_impl_file: syn::File = syn::parse2(axelar_executable_impl).unwrap();
+
+        prettyplease::unparse(&axelar_executable_impl_file)
+            .replace("pub fn ", "\npub fn ")
+            .replace("#[cfg(test)]", "\n#[cfg(test)]")
+    }
+
+    #[test]
+    fn axelar_executable_impl_generation_uses_configured_error_type() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(AxelarExecutable)]
+            #[axelar_executable(error = ContractError)]
+            pub struct Contract;
+        };
+
+        goldie::assert!(formatted_axelar_executable_impl(contract_input));
+    }
+
+    #[test]
+    fn axelar_executable_impl_generation_requires_error_type() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(AxelarExecutable)]
+            pub struct Contract;
+        };
+
+        let err = crate::axelar_executable::axelar_executable(&contract_input).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "AxelarExecutable requires #[axelar_executable(error = ContractError)]"
+        );
     }
 }

--- a/packages/stellar-axelar-std-derive/src/lib.rs
+++ b/packages/stellar-axelar-std-derive/src/lib.rs
@@ -14,7 +14,7 @@ mod upgradable;
 mod utils;
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, Attribute, DeriveInput, ItemFn, ItemImpl, Path};
+use syn::{parse_macro_input, DeriveInput, ItemFn, ItemImpl};
 
 /// Designates functions in an `impl` block as contract entrypoints.
 ///
@@ -188,6 +188,8 @@ pub fn when_not_paused(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// A `ContractError` error type must be defined in scope, and have a `MigrationNotAllowed` variant.
 /// A default migration implementation is automatically provided. If custom migration code is required,
 /// the `#[migratable]` attribute can be applied to the contract struct.
+/// It defaults to unit migration data. Use `#[migratable(data = MigrationData)]`
+/// if the migration needs a custom input type.
 /// In that case, the contract must implement the `CustomMigratableInterface` trait. The associated `Error` type
 /// must implement the `Into<ContractError>` trait. The `ContractError` type itself implements it implicitly,
 /// so that is an easy way to use it.
@@ -206,7 +208,7 @@ pub fn when_not_paused(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// #[contract]
 /// #[derive(Ownable, Upgradable)]
-/// #[migratable]
+/// #[migratable(data = Address)]
 /// pub struct Contract;
 ///
 /// #[contractimpl]
@@ -231,11 +233,9 @@ pub fn when_not_paused(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn derive_upgradable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    upgradable::upgradable(&input).into()
-}
-
-fn ensure_no_args(attr: &Attribute) -> syn::Result<&Path> {
-    attr.meta.require_path_only()
+    upgradable::upgradable(&input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Implements the Event trait for a Stellar contract event.
@@ -295,12 +295,57 @@ pub fn derive_its_executable(input: TokenStream) -> TokenStream {
     its_executable::its_executable(name).into()
 }
 
-#[proc_macro_derive(AxelarExecutable)]
+/// Implements the Axelar Executable interface for a Soroban contract.
+///
+/// The concrete error type must be specified with `#[axelar_executable(error = ...)]`.
+/// It must match the contract's `CustomAxelarExecutable::Error` associated type and
+/// define a `NotApproved` variant used when the gateway has not approved the message.
+///
+/// # Example
+/// ```rust,ignore
+/// # mod test {
+/// # use stellar_axelar_std::{contract, contracterror, Address, Bytes, Env, String};
+/// use stellar_axelar_std_derive::AxelarExecutable;
+/// use stellar_axelar_gateway::executable::CustomAxelarExecutable;
+///
+/// #[contracterror]
+/// #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// #[repr(u32)]
+/// pub enum ContractError {
+///     NotApproved = 1,
+/// }
+///
+/// #[contract]
+/// #[derive(AxelarExecutable)]
+/// #[axelar_executable(error = ContractError)]
+/// pub struct Contract;
+///
+/// impl CustomAxelarExecutable for Contract {
+///     type Error = ContractError;
+///
+///     fn __gateway(env: &Env) -> Address {
+///         todo!()
+///     }
+///
+///     fn __execute(
+///         env: &Env,
+///         source_chain: String,
+///         message_id: String,
+///         source_address: String,
+///         payload: Bytes,
+///     ) -> Result<(), Self::Error> {
+///         Ok(())
+///     }
+/// }
+/// # }
+/// ```
+#[proc_macro_derive(AxelarExecutable, attributes(axelar_executable))]
 pub fn derive_axelar_executable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
 
-    axelar_executable::axelar_executable(name).into()
+    axelar_executable::axelar_executable(&input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Ensures that only a contract's owner can execute the attributed function.
@@ -431,14 +476,4 @@ pub fn contractstorage(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
     contractstorage::contract_storage(&input).into()
-}
-
-trait MapTranspose<T> {
-    fn map_transpose<U, E, F: FnOnce(T) -> Result<U, E>>(self, f: F) -> Result<Option<U>, E>;
-}
-
-impl<T> MapTranspose<T> for Option<T> {
-    fn map_transpose<U, E, F: FnOnce(T) -> Result<U, E>>(self, f: F) -> Result<Option<U>, E> {
-        self.map(f).transpose()
-    }
 }

--- a/packages/stellar-axelar-std-derive/src/testdata/axelar_executable_impl_generation_uses_configured_error_type.golden
+++ b/packages/stellar-axelar-std-derive/src/testdata/axelar_executable_impl_generation_uses_configured_error_type.golden
@@ -1,0 +1,26 @@
+use stellar_axelar_gateway::executable::AxelarExecutableInterface as _;
+impl stellar_axelar_gateway::executable::DeriveOnly for Contract {}
+#[stellar_axelar_std::contractimpl]
+impl AxelarExecutableInterface for Contract {
+    #[allow_during_migration]
+    fn gateway(env: &Env) -> Address {
+        Self::__gateway(env)
+    }
+    fn execute(
+        env: &Env,
+        source_chain: String,
+        message_id: String,
+        source_address: String,
+        payload: Bytes,
+    ) -> Result<(), ContractError> {
+        stellar_axelar_gateway::executable::validate_message::<
+            Self,
+        >(env, &source_chain, &message_id, &source_address, &payload)
+            .map_err(|err| match err {
+                stellar_axelar_gateway::executable::ValidationError::NotApproved => {
+                    ContractError::NotApproved
+                }
+            })?;
+        Self::__execute(env, source_chain, message_id, source_address, payload)
+    }
+}

--- a/packages/stellar-axelar-std-derive/src/testdata/custom_upgradable_impl_generation_defaults_to_unit_migration_data.golden
+++ b/packages/stellar-axelar-std-derive/src/testdata/custom_upgradable_impl_generation_defaults_to_unit_migration_data.golden
@@ -20,7 +20,7 @@ impl stellar_axelar_std::interfaces::UpgradableInterface for Contract {
 impl stellar_axelar_std::interfaces::MigratableInterface for Contract {
     type Error = ContractError;
     #[allow_during_migration]
-    fn migrate(env: &Env, migration_data: MigrationData) -> Result<(), ContractError> {
+    fn migrate(env: &Env, migration_data: ()) -> Result<(), ContractError> {
         stellar_axelar_std::interfaces::migrate::<Self>(env, migration_data)
             .map_err(|err| match err {
                 stellar_axelar_std::interfaces::MigrationError::NotAllowed => {

--- a/packages/stellar-axelar-std-derive/src/testdata/default_upgradable_impl_generation_uses_unit_migration_data.golden
+++ b/packages/stellar-axelar-std-derive/src/testdata/default_upgradable_impl_generation_uses_unit_migration_data.golden
@@ -20,7 +20,7 @@ impl stellar_axelar_std::interfaces::UpgradableInterface for Contract {
 impl stellar_axelar_std::interfaces::MigratableInterface for Contract {
     type Error = ContractError;
     #[allow_during_migration]
-    fn migrate(env: &Env, migration_data: MigrationData) -> Result<(), ContractError> {
+    fn migrate(env: &Env, migration_data: ()) -> Result<(), ContractError> {
         stellar_axelar_std::interfaces::migrate::<Self>(env, migration_data)
             .map_err(|err| match err {
                 stellar_axelar_std::interfaces::MigrationError::NotAllowed => {
@@ -30,5 +30,15 @@ impl stellar_axelar_std::interfaces::MigratableInterface for Contract {
                     err.into()
                 }
             })
+    }
+}
+impl stellar_axelar_std::interfaces::CustomMigratableInterface for Contract {
+    type MigrationData = ();
+    type Error = ContractError;
+    fn __migrate(
+        _env: &Env,
+        _migration_data: Self::MigrationData,
+    ) -> Result<(), Self::Error> {
+        Ok(())
     }
 }

--- a/packages/stellar-axelar-std-derive/src/upgradable.rs
+++ b/packages/stellar-axelar-std-derive/src/upgradable.rs
@@ -1,32 +1,16 @@
-use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::quote;
-use syn::DeriveInput;
+use syn::{DeriveInput, Error, Type};
 
-use crate::{ensure_no_args, MapTranspose};
-
-pub fn upgradable(input: &DeriveInput) -> TokenStream2 {
+pub fn upgradable(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
+    let migration_data_type = migration_data_type(input)?;
+    let (custom_migration_impl, migration_data_type) = migration_data_type.map_or_else(
+        || (default_custom_migration(name), quote! { () }),
+        |migration_data_type| (quote! {}, quote! { #migration_data_type }),
+    );
 
-    let migration_kind = input
-        .attrs
-        .iter()
-        .filter(|attr| attr.path().is_ident("migratable"))
-        .at_most_one()
-        .expect("migratable attribute can only be applied once")
-        .map_transpose(ensure_no_args)
-        .expect("migratable attribute cannot have arguments")
-        .map(|_| MigrationKind::Custom)
-        .unwrap_or_default();
-
-    let custom_migration_impl = match migration_kind {
-        MigrationKind::Default => default_custom_migration(name),
-        MigrationKind::Custom => quote! {},
-    };
-
-    let migration_data_alias = Ident::new(&format!("__{}MigrationData", name), name.span());
-
-    quote! {
+    Ok(quote! {
         use stellar_axelar_std::interfaces::{UpgradableInterface as _, MigratableInterface as _};
 
         #[stellar_axelar_std::contractimpl]
@@ -49,15 +33,12 @@ pub fn upgradable(input: &DeriveInput) -> TokenStream2 {
             }
         }
 
-        #[allow(non_camel_case_types)]
-        type #migration_data_alias = <#name as stellar_axelar_std::interfaces::CustomMigratableInterface>::MigrationData;
-
         #[stellar_axelar_std::contractimpl]
         impl stellar_axelar_std::interfaces::MigratableInterface for #name {
             type Error = ContractError;
 
             #[allow_during_migration]
-            fn migrate(env: &Env, migration_data: #migration_data_alias) -> Result<(), ContractError> {
+            fn migrate(env: &Env, migration_data: #migration_data_type) -> Result<(), ContractError> {
                 stellar_axelar_std::interfaces::migrate::<Self>(env, migration_data)
                     .map_err(|err| match err {
                         stellar_axelar_std::interfaces::MigrationError::NotAllowed => ContractError::MigrationNotAllowed,
@@ -68,7 +49,7 @@ pub fn upgradable(input: &DeriveInput) -> TokenStream2 {
         }
 
         #custom_migration_impl
-    }
+    })
 }
 
 fn default_custom_migration(name: &Ident) -> TokenStream2 {
@@ -84,11 +65,52 @@ fn default_custom_migration(name: &Ident) -> TokenStream2 {
     }
 }
 
-#[derive(Default)]
-pub enum MigrationKind {
-    #[default]
-    Default,
-    Custom,
+fn migration_data_type(input: &DeriveInput) -> syn::Result<Option<Type>> {
+    let mut migration_data_type = None;
+    let mut has_migratable_attr = false;
+
+    for attr in input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("migratable"))
+    {
+        if has_migratable_attr {
+            return Err(Error::new_spanned(
+                attr,
+                "migratable attribute can only be specified once",
+            ));
+        }
+
+        has_migratable_attr = true;
+
+        if attr.meta.require_path_only().is_ok() {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("data") {
+                return Err(meta.error("unsupported migratable attribute"));
+            }
+
+            if migration_data_type.is_some() {
+                return Err(Error::new_spanned(
+                    &meta.path,
+                    "migration data type can only be specified once",
+                ));
+            }
+
+            let value = meta.value()?;
+            migration_data_type = Some(value.parse()?);
+            Ok(())
+        })?;
+    }
+
+    Ok(match (has_migratable_attr, migration_data_type) {
+        (false, None) => None,
+        (false, Some(_)) => unreachable!("migration data type requires a migratable attribute"),
+        (true, None) => Some(syn::parse_quote! { () }),
+        (true, Some(migration_data_type)) => Some(migration_data_type),
+    })
 }
 
 /// Tests the upgradable impl generation for a contract.
@@ -100,12 +122,49 @@ mod tests {
         let contract_input: syn::DeriveInput = syn::parse_quote! {
             #[contract]
             #[derive(Ownable, Upgradable)]
+            #[migratable(data = MigrationData)]
+            pub struct Contract;
+        };
+
+        let upgradable_impl: proc_macro2::TokenStream =
+            crate::upgradable::upgradable(&contract_input).unwrap();
+        let upgradable_impl_file: syn::File = syn::parse2(upgradable_impl).unwrap();
+        let formatted_upgradable_impl = prettyplease::unparse(&upgradable_impl_file)
+            .replace("pub fn ", "\npub fn ")
+            .replace("#[cfg(test)]", "\n#[cfg(test)]");
+
+        goldie::assert!(formatted_upgradable_impl);
+    }
+
+    #[test]
+    fn default_upgradable_impl_generation_uses_unit_migration_data() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(Ownable, Upgradable)]
+            pub struct Contract;
+        };
+
+        let upgradable_impl: proc_macro2::TokenStream =
+            crate::upgradable::upgradable(&contract_input).unwrap();
+        let upgradable_impl_file: syn::File = syn::parse2(upgradable_impl).unwrap();
+        let formatted_upgradable_impl = prettyplease::unparse(&upgradable_impl_file)
+            .replace("pub fn ", "\npub fn ")
+            .replace("#[cfg(test)]", "\n#[cfg(test)]");
+
+        goldie::assert!(formatted_upgradable_impl);
+    }
+
+    #[test]
+    fn custom_upgradable_impl_generation_defaults_to_unit_migration_data() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(Ownable, Upgradable)]
             #[migratable]
             pub struct Contract;
         };
 
         let upgradable_impl: proc_macro2::TokenStream =
-            crate::upgradable::upgradable(&contract_input);
+            crate::upgradable::upgradable(&contract_input).unwrap();
         let upgradable_impl_file: syn::File = syn::parse2(upgradable_impl).unwrap();
         let formatted_upgradable_impl = prettyplease::unparse(&upgradable_impl_file)
             .replace("pub fn ", "\npub fn ")

--- a/packages/stellar-axelar-std-derive/src/upgradable.rs
+++ b/packages/stellar-axelar-std-derive/src/upgradable.rs
@@ -105,12 +105,13 @@ fn migration_data_type(input: &DeriveInput) -> syn::Result<Option<Type>> {
         })?;
     }
 
-    Ok(match (has_migratable_attr, migration_data_type) {
-        (false, None) => None,
-        (false, Some(_)) => unreachable!("migration data type requires a migratable attribute"),
-        (true, None) => Some(syn::parse_quote! { () }),
-        (true, Some(migration_data_type)) => Some(migration_data_type),
-    })
+    if !has_migratable_attr {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        migration_data_type.unwrap_or_else(|| syn::parse_quote! { () }),
+    ))
 }
 
 /// Tests the upgradable impl generation for a contract.
@@ -171,5 +172,54 @@ mod tests {
             .replace("#[cfg(test)]", "\n#[cfg(test)]");
 
         goldie::assert!(formatted_upgradable_impl);
+    }
+
+    #[test]
+    fn upgradable_impl_generation_rejects_duplicate_migratable_attribute() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(Ownable, Upgradable)]
+            #[migratable]
+            #[migratable]
+            pub struct Contract;
+        };
+
+        let err = crate::upgradable::upgradable(&contract_input).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "migratable attribute can only be specified once"
+        );
+    }
+
+    #[test]
+    fn upgradable_impl_generation_rejects_unsupported_migratable_attribute() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(Ownable, Upgradable)]
+            #[migratable(unsupported = Foo)]
+            pub struct Contract;
+        };
+
+        let err = crate::upgradable::upgradable(&contract_input).unwrap_err();
+
+        assert_eq!(err.to_string(), "unsupported migratable attribute");
+    }
+
+    #[test]
+    fn upgradable_impl_generation_rejects_duplicate_migration_data_type() {
+        let contract_input: syn::DeriveInput = syn::parse_quote! {
+            #[contract]
+            #[derive(Ownable, Upgradable)]
+            #[migratable(data = MigrationData, data = OtherData)]
+            pub struct Contract;
+        };
+
+        let err = crate::upgradable::upgradable(&contract_input).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "migration data type can only be specified once"
+        );
     }
 }

--- a/packages/stellar-axelar-std/src/interfaces/testdata/contract_non_trivial_migration.rs
+++ b/packages/stellar-axelar-std/src/interfaces/testdata/contract_non_trivial_migration.rs
@@ -9,7 +9,7 @@ use crate::interfaces::testdata::contract_trivial_migration::DataKey;
 use crate::interfaces::{operatable, ownable, CustomMigratableInterface};
 
 #[derive(Upgradable, Ownable)]
-#[migratable]
+#[migratable(data = MigrationData)]
 #[contract]
 pub struct ContractNonTrivial;
 

--- a/packages/stellar-axelar-std/src/interfaces/upgradable.rs
+++ b/packages/stellar-axelar-std/src/interfaces/upgradable.rs
@@ -31,7 +31,10 @@ pub trait MigratableInterface: UpgradableInterface + CustomMigratableInterface {
 }
 
 /// This trait is used to implement custom migration logic for a contract.
+///
 /// It is automatically implemented for the contract if the `#[migratable]` attribute is applied to the contract struct.
+/// Bare `#[migratable]` uses unit migration data; use `#[migratable(data = MigrationData)]`
+/// for a custom input type.
 ///
 /// Do NOT add the implementation of [`CustomMigratableInterface`] to the public interface of the contract, i.e. do not annotate the `impl` block with `#[contractimpl]`
 pub trait CustomMigratableInterface: UpgradableInterface {

--- a/packages/stellar-axelar-std/src/tests/testdata/contract.rs
+++ b/packages/stellar-axelar-std/src/tests/testdata/contract.rs
@@ -18,7 +18,7 @@ pub enum ContractError {
 
 #[contract]
 #[derive(Ownable, Upgradable)]
-#[migratable]
+#[migratable(data = ())]
 pub struct Contract;
 
 #[derive(Debug, PartialEq, Eq, IntoEvent)]


### PR DESCRIPTION
Depends on #386 

Fixes CPI-82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated public contract entrypoint signatures and is a breaking API for every `AxelarExecutable`/`Upgradable` consumer, though runtime behavior should match; incorrect error or migration types would surface at compile time.
> 
> **Overview**
> Stops emitting **internal type aliases** in derived `AxelarExecutable` and `Upgradable` impls so Soroban contract specs stay clean (CPI-82).
> 
> **`AxelarExecutable`** now requires an explicit `#[axelar_executable(error = …)]` on the contract struct; generated `execute` uses that error type directly instead of a `__{Name}AxelarExecutableInterfaceError` alias tied to `CustomAxelarExecutable::Error`. Example and ITS contracts adopt the new attribute.
> 
> **`Upgradable` / `#[migratable]`** now puts the migration payload type in the public `migrate` signature via `#[migratable(data = MigrationData)]` (or `()` for bare `#[migratable]` / default upgradable), replacing the old `__{Name}MigrationData` associated-type alias. Macro parsing returns compile errors for duplicate or unsupported attributes; goldie tests cover expansion.
> 
> Call sites and test contracts are updated to the new attribute shapes; macro docs in `lib.rs` and `upgradable.rs` are refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea695878f4a088021fc42fad13c1cc2698386d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->